### PR TITLE
Fix external registry path generation

### DIFF
--- a/charts/helm_lib/templates/_module_image.tpl
+++ b/charts/helm_lib/templates/_module_image.tpl
@@ -13,7 +13,7 @@
   {{- if index $context.Values $moduleName }}
     {{- if index $context.Values $moduleName "registry" }}
       {{- if index $context.Values $moduleName "registry" "base" }}
-        {{- $registryBase = index $context.Values $moduleName "registry" "base" }}
+        {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $moduleName) }}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -32,7 +32,7 @@
     {{- if index $context.Values $moduleName }}
       {{- if index $context.Values $moduleName "registry" }}
         {{- if index $context.Values $moduleName "registry" "base" }}
-          {{- $registryBase = index $context.Values $moduleName "registry" "base" }}
+          {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $moduleName) }}
         {{- end }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
For third party modules we have to have a path like: `dev-registry.deckhouse.io/deckhouse/external-modules/echoserver:$checksum` and current code generates: `dev-registry.deckhouse.io/deckhouse/external-modules:$checksum`

Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>