### PR TITLE
Fix module_image name for external modules

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.1.1
+version: 1.1.2
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_image.tpl
+++ b/charts/helm_lib/templates/_module_image.tpl
@@ -13,10 +13,11 @@
   {{- fail $error }}
   {{- end }}
   {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
+  {{/*  handle external modules registry*/}}
   {{- if index $context.Values $moduleName }}
     {{- if index $context.Values $moduleName "registry" }}
       {{- if index $context.Values $moduleName "registry" "base" }}
-        {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $moduleName) }}
+        {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $context.Chart.Name) }}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -38,7 +39,7 @@
     {{- if index $context.Values $moduleName }}
       {{- if index $context.Values $moduleName "registry" }}
         {{- if index $context.Values $moduleName "registry" "base" }}
-          {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $moduleName) }}
+          {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $context.Chart.Name) }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/tests/templates/helm_lib_module_image.yaml
+++ b/tests/templates/helm_lib_module_image.yaml
@@ -1,2 +1,3 @@
 withContext: {{ include "helm_lib_module_image" (list . "testContainer") }}
 optionalModuleName: {{ include "helm_lib_module_image" (list . "testContainer" "fooBar") }}
+externalModuleImage: {{ include "helm_lib_module_image" (list . "testContainer") }}

--- a/tests/tests/helm_lib_module_image_test.yaml
+++ b/tests/tests/helm_lib_module_image_test.yaml
@@ -20,3 +20,22 @@ tests:
       - equal:
           path: "optionalModuleName"
           value: "deckhouse.io/deckhouse/ce@sha345"
+
+  - it: should render external module image
+    set:
+      global:
+        modulesImages:
+          registry:
+            base: "deckhouse.io/deckhouse/ce"
+          digests:
+            testModule:
+              testContainer: "sha678"
+            fooBar:
+              testContainer: "sha345"
+      testModule:
+        registry:
+          base: "deckhouse.io/external-modules"
+    asserts:
+      - equal:
+          path: "externalModuleImage"
+          value: "deckhouse.io/external-modules/test-module@sha678"


### PR DESCRIPTION
We should not camelCase a module name for external modules