### PR TITLE
module-image: Fix comment line

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.1.2
+version: 1.1.3
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_image.tpl
+++ b/charts/helm_lib/templates/_module_image.tpl
@@ -13,7 +13,7 @@
   {{- fail $error }}
   {{- end }}
   {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
-  {{/*  handle external modules registry*/}}
+  {{- /*  handle external modules registry */}}
   {{- if index $context.Values $moduleName }}
     {{- if index $context.Values $moduleName "registry" }}
       {{- if index $context.Values $moduleName "registry" "base" }}


### PR DESCRIPTION
Without '-' in the beginning of the line "helm_lib_module_image" function generates an extra empty line in the output template