### PR TITLE
Add domain name validation to `helm_lib_module_public_domain`

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.3.0
+version: 1.4.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_public_domain.tpl
+++ b/charts/helm_lib/templates/_module_public_domain.tpl
@@ -7,5 +7,13 @@
   {{- if not (contains "%s" $context.Values.global.modules.publicDomainTemplate) }}
     {{ fail "Error!!! global.modules.publicDomainTemplate must contain \"%s\" pattern to render service fqdn!" }}
   {{- end }}
-  {{- printf $context.Values.global.modules.publicDomainTemplate $name_portion }}
+
+  {{ $domain := printf $context.Values.global.modules.publicDomainTemplate $name_portion }}
+
+  {{ $domain_length := len $domain }}
+  {{- if gt $domain_length 64 -}}
+    {{ fail "domain name must be not longer than 64 characters" }}
+  {{- end -}}
+
+  {{- print $domain }}
 {{- end }}

--- a/tests/templates/helm_lib_module_public_domain.yaml
+++ b/tests/templates/helm_lib_module_public_domain.yaml
@@ -1,0 +1,1 @@
+test: {{ include "helm_lib_module_public_domain" (list . .Values.prefix) }}

--- a/tests/tests/helm_lib_module_public_domain_test.yaml
+++ b/tests/tests/helm_lib_module_public_domain_test.yaml
@@ -1,0 +1,40 @@
+suite: helm_lib_module_public_domain_test definition
+templates:
+  - helm_lib_module_public_domain.yaml
+tests:
+  - it: returns test.com
+
+    set:
+      prefix: test
+      global:
+        modules:
+          publicDomainTemplate: "%s.com"
+
+    asserts:
+      - equal:
+          path: "test"
+          value: "test.com"
+
+  - it: should failed to render without "%s" pattern
+
+    set:
+      prefix: test
+      global:
+        modules:
+          publicDomainTemplate: .com
+
+    asserts:
+      - failedTemplate:
+          errorMessage: 'Error!!! global.modules.publicDomainTemplate must contain "%s" pattern to render service fqdn!'
+
+  - it: should failed to render with too long domain name
+
+    set:
+      prefix: test.test.test.test.test.test.test.test.test.test.test.test.test.test
+      global:
+        modules:
+          publicDomainTemplate: "%s.com"
+
+    asserts:
+      - failedTemplate:
+          errorMessage: "domain name must be not longer than 64 characters"


### PR DESCRIPTION
Add domain name validation to `helm_lib_module_public_domain` helm helper.

We need it for [issue](https://github.com/deckhouse/deckhouse/issues/4926).