### PR TITLE
add module_documentation_uri definition

### DIFF
--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -11,6 +11,8 @@
 | [helm_lib_ha_enabled](#helm_lib_ha_enabled) |
 | **Kube Rbac Proxy** |
 | [helm_lib_kube_rbac_proxy_ca_certificate](#helm_lib_kube_rbac_proxy_ca_certificate) |
+| **Module Documentation Uri** |
+| [helm_lib_module_documentation_uri](#helm_lib_module_documentation_uri) |
 | **Module Ephemeral Storage** |
 | [helm_lib_module_ephemeral_storage_logs_with_extra](#helm_lib_module_ephemeral_storage_logs_with_extra) |
 | [helm_lib_module_ephemeral_storage_only_logs](#helm_lib_module_ephemeral_storage_only_logs) |
@@ -152,6 +154,17 @@ list:
 list:
 -  Template context with .Values, .Chart, etc 
 -  Namespace where CA configmap will be created  
+
+## Module Documentation Uri
+
+### helm_lib_module_documentation_uri
+
+ returns rendered documentation uri using publicDomainTemplate or deckhouse.io domains
+
+#### Usage
+
+`{{ include "helm_lib_module_documentation_uri" (list . "<path_to_document>") }} `
+
 
 ## Module Ephemeral Storage
 

--- a/charts/helm_lib/templates/_module_documentation_uri.tpl
+++ b/charts/helm_lib/templates/_module_documentation_uri.tpl
@@ -1,0 +1,15 @@
+{{- /* Usage: {{ include "helm_lib_module_documentation_uri" (list . "<path_to_document>") }} */ -}}
+{{- /* returns rendered documentation uri using publicDomainTemplate or deckhouse.io domains*/ -}}
+{{- define "helm_lib_module_documentation_uri" }}
+  {{- $default_doc_prefix := "https://deckhouse.io/documentation/v1" -}}
+  {{- $context      := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $path_portion := index . 1 -}} {{- /* Path to the document */ -}}
+  {{- $uri := "" -}}
+  {{- if $context.Values.global.modules.publicDomainTemplate }}
+     {{- $uri = printf "%s://%s%s" (include "helm_lib_module_uri_scheme" $context) (include "helm_lib_module_public_domain" (list $context "documentation")) $path_portion -}}
+  {{- else }}
+     {{- $uri = printf "%s%s" $default_doc_prefix $path_portion -}}
+  {{- end }}
+
+  {{ $uri }}
+{{- end }}

--- a/tests/templates/helm_lib_module_documentation_uri.yaml
+++ b/tests/templates/helm_lib_module_documentation_uri.yaml
@@ -1,0 +1,1 @@
+uri: '{{ include "helm_lib_module_documentation_uri" (list . "/modules/123-my-module/faq.html#how-to-module") }}'

--- a/tests/tests/helm_lib_module_documentation_uri_test.yaml
+++ b/tests/tests/helm_lib_module_documentation_uri_test.yaml
@@ -1,0 +1,77 @@
+suite: helm_lib_module_documentation_uri_test definition
+templates:
+  - helm_lib_module_documentation_uri.yaml
+tests:
+  - it: returns an http url to custom documentation domain
+
+    set:
+      prefix: test
+      global:
+        modules:
+          https:
+            mode: Disabled
+          publicDomainTemplate: "%s.test.com"
+
+    asserts:
+      - equal:
+          path: "uri"
+          value: "http://documentation.test.com/modules/123-my-module/faq.html#how-to-module"
+
+  - it: returns an https url to custom documentation domain
+
+    set:
+      prefix: test
+      global:
+        modules:
+          https:
+            mode: CertManager
+          publicDomainTemplate: "%s.test.com"
+
+    asserts:
+      - equal:
+          path: "uri"
+          value: "https://documentation.test.com/modules/123-my-module/faq.html#how-to-module"
+
+  - it: returns an https url to custom documentation domain
+
+    set:
+      prefix: test
+      global:
+        modules:
+          https:
+            mode: CustomCertificate
+          publicDomainTemplate: "%s.test.com"
+
+    asserts:
+      - equal:
+          path: "uri"
+          value: "https://documentation.test.com/modules/123-my-module/faq.html#how-to-module"
+
+  - it: returns an https url to custom documentation domain
+
+    set:
+      prefix: test
+      global:
+        modules:
+          https:
+            mode: OnlyInUri
+          publicDomainTemplate: "%s.test.com"
+
+    asserts:
+      - equal:
+          path: "uri"
+          value: "https://documentation.test.com/modules/123-my-module/faq.html#how-to-module"
+
+  - it: returns an https url to public documentation domain
+
+    set:
+      prefix: test
+      global:
+        modules:
+          https:
+            mode: OnlyInUri
+
+    asserts:
+      - equal:
+          path: "uri"
+          value: "https://deckhouse.io/documentation/v1/modules/123-my-module/faq.html#how-to-module"


### PR DESCRIPTION
Add helm_lib_module_documentation_uri definition so it would return a valid domain + path to a documentation depending on publicDomainTemplate global value instead of [duplicating](https://github.com/deckhouse/deckhouse/commit/44c8baf76598edcc2a19d65172524dafb28106ee#diff-7301b520556a446bd848672620e8c0380430e911b6f657572fe51e3ee00ad68eR14-R28).