### PR TITLE
build registryBase with join func

### DIFF
--- a/charts/helm_lib/templates/_module_image.tpl
+++ b/charts/helm_lib/templates/_module_image.tpl
@@ -17,7 +17,9 @@
   {{- if index $context.Values $moduleName }}
     {{- if index $context.Values $moduleName "registry" }}
       {{- if index $context.Values $moduleName "registry" "base" }}
-        {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $context.Chart.Name) }}
+        {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+        {{- $path := trimAll "/" $context.Chart.Name }}
+        {{- $registryBase = join "/" (list $host $path) }}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -39,7 +41,9 @@
     {{- if index $context.Values $moduleName }}
       {{- if index $context.Values $moduleName "registry" }}
         {{- if index $context.Values $moduleName "registry" "base" }}
-          {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $context.Chart.Name) }}
+          {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+          {{- $path := trimAll "/" $context.Chart.Name }}
+          {{- $registryBase = join "/" (list $host $path) }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/tests/tests/helm_lib_module_image_test.yaml
+++ b/tests/tests/helm_lib_module_image_test.yaml
@@ -39,3 +39,22 @@ tests:
       - equal:
           path: "externalModuleImage"
           value: "deckhouse.io/external-modules/test-module@sha678"
+  
+  - it: should render external module image with trail slash
+    set:
+      global:
+        modulesImages:
+          registry:
+            base: "deckhouse.io/deckhouse/ce"
+          digests:
+            testModule:
+              testContainer: "sha678"
+            fooBar:
+              testContainer: "sha345"
+      testModule:
+        registry:
+          base: "deckhouse.io/external-modules/"
+    asserts:
+      - equal:
+          path: "externalModuleImage"
+          value: "deckhouse.io/external-modules/test-module@sha678"


### PR DESCRIPTION
For issue https://github.com/deckhouse/deckhouse/issues/5108
Replace registryBase build from printf to join (there was attempt with urlJoin but it work fine with only canonical url with scheme and others parts of url)