### PR TITLE
SecurityContext "deckhouse" user

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.6.0
+version: 1.7.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -43,6 +43,8 @@
 | [helm_lib_module_pod_security_context_run_as_user_custom](#helm_lib_module_pod_security_context_run_as_user_custom) |
 | [helm_lib_module_pod_security_context_run_as_user_nobody](#helm_lib_module_pod_security_context_run_as_user_nobody) |
 | [helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs) |
+| [helm_lib_module_pod_security_context_run_as_user_deckhouse](#helm_lib_module_pod_security_context_run_as_user_deckhouse) |
+| [helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs) |
 | [helm_lib_module_pod_security_context_run_as_user_root](#helm_lib_module_pod_security_context_run_as_user_root) |
 | [helm_lib_module_container_security_context_not_allow_privilege_escalation](#helm_lib_module_container_security_context_not_allow_privilege_escalation) |
 | [helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux](#helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux) |
@@ -452,7 +454,7 @@ list:
 
 ### helm_lib_module_pod_security_context_run_as_user_nobody
 
- returns PodSecurityContext parameters for Pod with user and group nobody 
+ returns PodSecurityContext parameters for Pod with user and group "nobody" 
 
 #### Usage
 
@@ -465,11 +467,37 @@ list:
 
 ### helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs
 
- returns PodSecurityContext parameters for Pod with user and group nobody with write access to mounted volumes 
+ returns PodSecurityContext parameters for Pod with user and group "nobody" with write access to mounted volumes 
 
 #### Usage
 
 `{{ include "helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
+
+
+### helm_lib_module_pod_security_context_run_as_user_deckhouse
+
+ returns PodSecurityContext parameters for Pod with user and group "deckhouse" 
+
+#### Usage
+
+`{{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
+
+
+### helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs
+
+ returns PodSecurityContext parameters for Pod with user and group "deckhouse" with write access to mounted volumes 
+
+#### Usage
+
+`{{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . }} `
 
 #### Arguments
 

--- a/charts/helm_lib/templates/_module_image.tpl
+++ b/charts/helm_lib/templates/_module_image.tpl
@@ -17,7 +17,9 @@
   {{- if index $context.Values $moduleName }}
     {{- if index $context.Values $moduleName "registry" }}
       {{- if index $context.Values $moduleName "registry" "base" }}
-        {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $context.Chart.Name) }}
+        {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+        {{- $path := trimAll "/" $context.Chart.Name }}
+        {{- $registryBase = join "/" (list $host $path) }}
       {{- end }}
     {{- end }}
   {{- end }}
@@ -39,7 +41,9 @@
     {{- if index $context.Values $moduleName }}
       {{- if index $context.Values $moduleName "registry" }}
         {{- if index $context.Values $moduleName "registry" "base" }}
-          {{- $registryBase = (printf "%s/%s" (index $context.Values $moduleName "registry" "base") $context.Chart.Name) }}
+          {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+          {{- $path := trimAll "/" $context.Chart.Name }}
+          {{- $registryBase = join "/" (list $host $path) }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/helm_lib/templates/_module_security_context.tpl
+++ b/charts/helm_lib/templates/_module_security_context.tpl
@@ -11,7 +11,7 @@ securityContext:
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_nobody" . }} */ -}}
-{{- /* returns PodSecurityContext parameters for Pod with user and group nobody */ -}}
+{{- /* returns PodSecurityContext parameters for Pod with user and group "nobody" */ -}}
 {{- define "helm_lib_module_pod_security_context_run_as_user_nobody" -}}
 {{- /* Template context with .Values, .Chart, etc */ -}}
 securityContext:
@@ -21,7 +21,7 @@ securityContext:
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs" . }} */ -}}
-{{- /* returns PodSecurityContext parameters for Pod with user and group nobody with write access to mounted volumes */ -}}
+{{- /* returns PodSecurityContext parameters for Pod with user and group "nobody" with write access to mounted volumes */ -}}
 {{- define "helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs" -}}
 {{- /* Template context with .Values, .Chart, etc */ -}}
 securityContext:
@@ -29,6 +29,27 @@ securityContext:
   runAsUser: 65534
   runAsGroup: 65534
   fsGroup: 65534
+{{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . }} */ -}}
+{{- /* returns PodSecurityContext parameters for Pod with user and group "deckhouse" */ -}}
+{{- define "helm_lib_module_pod_security_context_run_as_user_deckhouse" -}}
+{{- /* Template context with .Values, .Chart, etc */ -}}
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 64535
+  runAsGroup: 64535
+{{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . }} */ -}}
+{{- /* returns PodSecurityContext parameters for Pod with user and group "deckhouse" with write access to mounted volumes */ -}}
+{{- define "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" -}}
+{{- /* Template context with .Values, .Chart, etc */ -}}
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 64535
+  runAsGroup: 64535
+  fsGroup: 64535
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_root" . }} */ -}}

--- a/tests/tests/helm_lib_module_image_test.yaml
+++ b/tests/tests/helm_lib_module_image_test.yaml
@@ -39,3 +39,22 @@ tests:
       - equal:
           path: "externalModuleImage"
           value: "deckhouse.io/external-modules/test-module@sha678"
+  
+  - it: should render external module image with trail slash
+    set:
+      global:
+        modulesImages:
+          registry:
+            base: "deckhouse.io/deckhouse/ce"
+          digests:
+            testModule:
+              testContainer: "sha678"
+            fooBar:
+              testContainer: "sha345"
+      testModule:
+        registry:
+          base: "deckhouse.io/external-modules/"
+    asserts:
+      - equal:
+          path: "externalModuleImage"
+          value: "deckhouse.io/external-modules/test-module@sha678"


### PR DESCRIPTION
Similar to the "nobody" user, but the one that we'll use to identify processes belonging to the deckhouse distribution.