### PR TITLE
Change SecurityContext with SELinux to read-only filesystem

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.9.0
+version: 1.10.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -47,7 +47,7 @@
 | [helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs) |
 | [helm_lib_module_pod_security_context_run_as_user_root](#helm_lib_module_pod_security_context_run_as_user_root) |
 | [helm_lib_module_container_security_context_not_allow_privilege_escalation](#helm_lib_module_container_security_context_not_allow_privilege_escalation) |
-| [helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux](#helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux) |
+| [helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux](#helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux) |
 | [helm_lib_module_container_security_context_read_only_root_filesystem](#helm_lib_module_container_security_context_read_only_root_filesystem) |
 | [helm_lib_module_container_security_context_privileged](#helm_lib_module_container_security_context_privileged) |
 | [helm_lib_module_container_security_context_privileged_read_only_root_filesystem](#helm_lib_module_container_security_context_privileged_read_only_root_filesystem) |
@@ -527,13 +527,13 @@ list:
 
 
 
-### helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux
+### helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux
 
- returns SecurityContext parameters for Container with allowPrivilegeEscalation false and options for SELinux compatibility
+ returns SecurityContext parameters for Container with read only root filesystem and options for SELinux compatibility
 
 #### Usage
 
-`{{ include "helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux" . }} `
+`{{ include "helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux" . }} `
 
 #### Arguments
 

--- a/charts/helm_lib/templates/_module_security_context.tpl
+++ b/charts/helm_lib/templates/_module_security_context.tpl
@@ -69,11 +69,12 @@ securityContext:
   allowPrivilegeEscalation: false
 {{- end }}
 
-{{- /* Usage: {{ include "helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux" . }} */ -}}
-{{- /* returns SecurityContext parameters for Container with allowPrivilegeEscalation false and options for SELinux compatibility*/ -}}
-{{- define "helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux" -}}
+{{- /* Usage: {{ include "helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux" . }} */ -}}
+{{- /* returns SecurityContext parameters for Container with read only root filesystem and options for SELinux compatibility*/ -}}
+{{- define "helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux" -}}
 {{- /* Template context with .Values, .Chart, etc */ -}}
 securityContext:
+  readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   seLinuxOptions:
     level: 's0'

--- a/tests/templates/helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux.yaml
+++ b/tests/templates/helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux.yaml
@@ -1,1 +1,0 @@
-{{ include "helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux" . }}

--- a/tests/templates/helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux.yaml
+++ b/tests/templates/helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux.yaml
@@ -1,0 +1,1 @@
+{{ include "helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux" . }}

--- a/tests/tests/helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux_test.yaml
+++ b/tests/tests/helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux_test.yaml
@@ -1,6 +1,6 @@
-suite: helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux definition
+suite: helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux definition
 templates:
-  - helm_lib_module_container_security_context_not_allow_privilege_escalation_with_selinux.yaml
+  - helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux.yaml
 tests:
   - it: renders security context with SELinux options
 
@@ -8,6 +8,7 @@ tests:
       - equal:
           path: securityContext
           value:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             seLinuxOptions:
               level: 's0'


### PR DESCRIPTION
This template is only used in deckhouse-controller and we want to have a read-only filesystem there.