### PR TITLE
Add extraCreateMetadataEnabled param

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.21.0
+version: 1.22.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_csi_controller.tpl
+++ b/charts/helm_lib/templates/_csi_controller.tpl
@@ -37,6 +37,7 @@ memory: 50Mi
   {{- $snapshotterEnabled := dig "snapshotterEnabled" true $config }}
   {{- $resizerEnabled := dig "resizerEnabled" true $config }}
   {{- $topologyEnabled := dig "topologyEnabled" true $config }}
+  {{- $extraCreateMetadataEnabled := dig "extraCreateMetadataEnabled" false $config }}
   {{- $controllerImage := $config.controllerImage | required "$config.controllerImage is required" }}
   {{- $provisionerTimeout := $config.provisionerTimeout | default "600s" }}
   {{- $attacherTimeout := $config.attacherTimeout | default "600s" }}
@@ -197,6 +198,9 @@ spec:
         - "--leader-election-namespace=$(NAMESPACE)"
         - "--enable-capacity"
         - "--capacity-ownerref-level=2"
+  {{- if $extraCreateMetadataEnabled }}
+        - "--extra-create-metadata=true"
+  {{- end }}
         - "--worker-threads={{ $provisionerWorkers }}"
         env:
         - name: ADDRESS


### PR DESCRIPTION
This pull request introduces a new configuration parameter `extraCreateMetadataEnabled` to our deployment configuration for the CSI `provisioner` container. Enabling this parameter will append the --extra-create-metadata=true argument to the container's args.
