### PR TITLE
add security context for pss restricted

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.27.0
+version: 1.28.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -48,6 +48,7 @@
 | [helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs) |
 | [helm_lib_module_pod_security_context_run_as_user_deckhouse](#helm_lib_module_pod_security_context_run_as_user_deckhouse) |
 | [helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs) |
+| [helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted](#helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted) |
 | [helm_lib_module_pod_security_context_run_as_user_root](#helm_lib_module_pod_security_context_run_as_user_root) |
 | [helm_lib_module_pod_security_context_runtime_default](#helm_lib_module_pod_security_context_runtime_default) |
 | [helm_lib_module_container_security_context_not_allow_privilege_escalation](#helm_lib_module_container_security_context_not_allow_privilege_escalation) |
@@ -526,6 +527,19 @@ list:
 #### Usage
 
 `{{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
+
+
+### helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted
+
+ returns SecurityContext parameters for Container with user and group "deckhouse" plus minimal required settings to comply with the Restricted mode of the Pod Security Standards 
+
+#### Usage
+
+`{{ include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . }} `
 
 #### Arguments
 

--- a/charts/helm_lib/templates/_module_security_context.tpl
+++ b/charts/helm_lib/templates/_module_security_context.tpl
@@ -52,6 +52,22 @@ securityContext:
   fsGroup: 64535
 {{- end }}
 
+{{- /* Usage: {{ include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . }} */ -}}
+{{- /* returns SecurityContext parameters for Container with user and group "deckhouse" plus minimal required settings to comply with the Restricted mode of the Pod Security Standards */ -}}
+{{- define "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" -}}
+{{- /* Template context with .Values, .Chart, etc */ -}}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+  drop:
+  - all
+  runAsGroup: 64535
+  runAsNonRoot: true
+  runAsUser: 64535
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}
+
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_root" . }} */ -}}
 {{- /* returns PodSecurityContext parameters for Pod with user and group 0 */ -}}
 {{- define "helm_lib_module_pod_security_context_run_as_user_root" -}}

--- a/tests/templates/helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted.yaml
+++ b/tests/templates/helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted.yaml
@@ -1,0 +1,1 @@
+{{ include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . }}

--- a/tests/tests/helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted_test.yaml
+++ b/tests/tests/helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted_test.yaml
@@ -1,0 +1,19 @@
+suite: helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted
+templates:
+  - helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted.yaml
+tests:
+  - it: renders security context 
+
+    asserts:
+      - equal:
+          path: securityContext
+          value:
+            allowPrivilegeEscalation: false
+            capabilities:
+            drop:
+            - all
+            runAsGroup: 64535
+            runAsNonRoot: true
+            runAsUser: 64535
+            seccompProfile:
+              type: RuntimeDefault


### PR DESCRIPTION
Adds container security context with user/group set to `deckhouse` plus bare minimum to comply with PSS restricted mode
relates to https://github.com/deckhouse/deckhouse/issues/7680