### PR TITLE
add kind_exists helper

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.29.0
+version: 1.30.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -11,6 +11,8 @@
 | **High Availability** |
 | [helm_lib_is_ha_to_value](#helm_lib_is_ha_to_value) |
 | [helm_lib_ha_enabled](#helm_lib_ha_enabled) |
+| **Kind Exists** |
+| [helm_lib_kind_exists](#helm_lib_kind_exists) |
 | **Kube Rbac Proxy** |
 | [helm_lib_kube_rbac_proxy_ca_certificate](#helm_lib_kube_rbac_proxy_ca_certificate) |
 | **Module Documentation Uri** |
@@ -161,6 +163,22 @@ list:
 #### Arguments
 
 -  Template context with .Values, .Chart, etc 
+
+## Kind Exists
+
+### helm_lib_kind_exists
+
+ returns true if the specified resource kind (case-insensitive) is represented in the cluster 
+
+#### Usage
+
+`{{ include "helm_lib_kind_exists" (list . "<kind-name>") }} `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  Kind name portion 
 
 ## Kube Rbac Proxy
 

--- a/charts/helm_lib/templates/_kind_exists.tpl
+++ b/charts/helm_lib/templates/_kind_exists.tpl
@@ -1,0 +1,15 @@
+{{- /* Usage: {{ include "helm_lib_kind_exists" (list . "<kind-name>") }} */ -}}
+{{- /* returns true if the specified resource kind (case-insensitive) is represented in the cluster */ -}}
+{{- define "helm_lib_kind_exists" }}
+  {{- $context      := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $kind_name := index . 1 -}} {{- /* Kind name portion */ -}}
+  {{- if eq (len $context.Capabilities.APIVersions) 0 }}
+    {{- fail "Helm reports no capabilities" }}
+  {{- end }}
+  {{ range $cap := $context.Capabilities.APIVersions }}
+    {{- if hasSuffix (lower (printf "/%s" $kind_name)) (lower $cap) }}
+      found
+      {{- break }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/tests/templates/helm_lib_kind_exists.yaml
+++ b/tests/templates/helm_lib_kind_exists.yaml
@@ -1,0 +1,1 @@
+result: {{ include "helm_lib_kind_exists" (list . "validatingadmissionpolicy") }}

--- a/tests/tests/helm_lib_kind_exists_test.yaml
+++ b/tests/tests/helm_lib_kind_exists_test.yaml
@@ -1,0 +1,37 @@
+suite: helm_lib_kind_exists
+templates:
+  - helm_lib_kind_exists.yaml
+tests:
+  - it: returns found for the `ValidatingAdmissionPolicy` kind
+    capabilities:
+      apiVersions:
+        - apps/v1/ValidatingAdmissionPolicy
+    asserts:
+      - equal:
+          path: "result"
+          value: "found"
+
+  - it: returns found for the `ValidatingAdmissionPolicy` kind
+    capabilities:
+      apiVersions:
+        - apps/v1/validatingadmissionpolicy
+    asserts:
+      - equal:
+          path: "result"
+          value: "found"
+
+  - it: returns "" for the `ValidatingAdmissionPolicy` kind
+    capabilities:
+      apiVersions:
+        - apps/v1/SomeOtherPolicy
+    asserts:
+      - equal:
+          path: "result"
+          value: null
+
+  - it: returns errors for empt apiVersions
+    capabilities:
+      apiVersions:
+    asserts:
+      - failedTemplate:
+          errorMessage: "Helm reports no capabilities"


### PR DESCRIPTION
Adds `helm_lib_kind_exists` helm helper to check if helm capabilities functionality reports that the required `kind` is represented in the cluster.