### PR TITLE
Not annotate cloud-provider's storageClass-es as default

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.31.0
+version: 1.32.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.30.2
+version: 1.31.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_storage_class.tpl
+++ b/charts/helm_lib/templates/_module_storage_class.tpl
@@ -22,6 +22,12 @@
     {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
       {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
     {{- end }}
+  {{- else }}
+    {{- /* Annotate first StorageClass in list as default in case there is `global.discovery.defaultStorageClass` and */ -}}
+    {{- /* `global.defaultClusterStorageClass` NOT defined */ -}}
+    {{- if and (not $context.Values.global.defaultClusterStorageClass) (eq $sc_index 0) }}
+      {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
+    {{- end }}
   {{- end }}
 
 {{- (dict "annotations" $annotations) | toYaml -}}

--- a/charts/helm_lib/templates/_module_storage_class.tpl
+++ b/charts/helm_lib/templates/_module_storage_class.tpl
@@ -24,9 +24,11 @@
     {{- end }}
   {{- else }}
     {{- /* Annotate first StorageClass in list as default in case there is `global.discovery.defaultStorageClass` and */ -}}
-    {{- /* `global.defaultClusterStorageClass` NOT defined */ -}}
-    {{- if and (not $context.Values.global.defaultClusterStorageClass) (eq $sc_index 0) }}
-      {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
+    {{- /* `global.defaultClusterStorageClass` NOT defined/empty */ -}}
+    {{- if (eq $sc_index 0) }}
+      {{- if or (not (hasKey $context.Values.global "defaultClusterStorageClass")) (and (hasKey $context.Values.global "defaultClusterStorageClass") (not $context.Values.global.defaultClusterStorageClass)) }}
+        {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
+      {{- end }}
     {{- end }}
   {{- end }}
 

--- a/charts/helm_lib/templates/_module_storage_class.tpl
+++ b/charts/helm_lib/templates/_module_storage_class.tpl
@@ -18,19 +18,9 @@
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
   {{- end }}
 
-  {{- if hasKey $module_values.internal "defaultStorageClass" }}
-    {{- if eq $module_values.internal.defaultStorageClass $sc_name }}
+  {{- if $context.Values.global.discovery.defaultStorageClass }}
+    {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
       {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
-    {{- end }}
-  {{- else }}
-    {{- if eq $sc_index 0 }}
-      {{- if $context.Values.global.discovery.defaultStorageClass }}
-        {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
-          {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
-        {{- end }}
-      {{- else }}
-        {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}
-      {{- end }}
     {{- end }}
   {{- end }}
 

--- a/tests/templates/helm_lib_module_storage_class.yaml
+++ b/tests/templates/helm_lib_module_storage_class.yaml
@@ -1,0 +1,1 @@
+{{ include "helm_lib_module_storage_class_annotations" (list $ "0" "cloud-provider-storageclass") }}

--- a/tests/templates/helm_lib_module_storage_class.yaml
+++ b/tests/templates/helm_lib_module_storage_class.yaml
@@ -1,1 +1,4 @@
-{{ include "helm_lib_module_storage_class_annotations" (list $ "0" "cloud-provider-storageclass") }}
+{{- range $index, $storageClass := (list "first-storageclass" "second-storageclass" "third-storageclass") }}
+---
+{{ include "helm_lib_module_storage_class_annotations" (list $ $index $storageClass) }}
+{{- end }}

--- a/tests/tests/helm_lib_module_storage_class_test.yaml
+++ b/tests/tests/helm_lib_module_storage_class_test.yaml
@@ -66,3 +66,25 @@ tests:
       - equal:
           path: annotations
           value: {}
+
+  - it: only first-storageclass should set as default if discovery.defaultStorageClass is empty and global.defaultClusterStorageClass NOT DEFINED
+    set:
+      global:
+        discovery:
+          defaultStorageClass: ""
+
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: annotations["storageclass.kubernetes.io/is-default-class"]
+          value: "true"
+
+      - documentIndex: 1
+        equal:
+          path: annotations
+          value: {}
+
+      - documentIndex: 2
+        equal:
+          path: annotations
+          value: {}

--- a/tests/tests/helm_lib_module_storage_class_test.yaml
+++ b/tests/tests/helm_lib_module_storage_class_test.yaml
@@ -2,10 +2,51 @@ suite: helm_lib_module_storage_class_test definition
 templates:
   - helm_lib_module_storage_class.yaml
 tests:
-  - it: should not contain default storage class annotation if no discovery.defaultStorageClass is set
-
+  - it: only first-storageclass should set as default if no discovery.defaultStorageClass and no global.defaultClusterStorageClass is set
     set:
       global:
+        defaultClusterStorageClass: ""
+        discovery:
+          defaultStorageClass: ""
+
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: annotations["storageclass.kubernetes.io/is-default-class"]
+          value: "true"
+
+      - documentIndex: 1
+        equal:
+          path: annotations
+          value: {}
+
+      - documentIndex: 2
+        equal:
+          path: annotations
+          value: {}
+
+  - it: should contains default storage class annotation for second-storageclass set in discovery.defaultStorageClass
+    set:
+      global:
+        discovery:
+          # set as in tests/templates/helm_lib_module_storage_class.yaml
+          defaultStorageClass: "second-storageclass"
+
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: annotations
+          value: {}
+
+      - documentIndex: 1
+        equal:
+          path: annotations["storageclass.kubernetes.io/is-default-class"]
+          value: "true"
+
+  - it: should not contains default storage class annotations if global.defaultClusterStorageClass is set
+    set:
+      global:
+        defaultClusterStorageClass: "second-storageclass"
         discovery:
           defaultStorageClass: ""
 
@@ -14,27 +55,14 @@ tests:
           path: annotations
           value: {}
 
-  - it: should contain default storage class annotation
 
+  - it: should not contains default storage class annotation if there is wrong value in discovery.defaultStorageClass
     set:
       global:
         discovery:
-          # set as in tests/templates/helm_lib_module_storage_class.yaml
-          defaultStorageClass: "cloud-provider-storageclass"
+          defaultStorageClass: "other-storageclass"
 
     asserts:
       - equal:
-          path: annotations["storageclass.kubernetes.io/is-default-class"]
-          value: "true"
-
-  # - it: should failed to render without "%s" pattern
-
-  #   set:
-  #     prefix: test
-  #     global:
-  #       modules:
-  #         publicDomainTemplate: .com
-
-  #   asserts:
-  #     - failedTemplate:
-  #         errorMessage: 'Error!!! global.modules.publicDomainTemplate must contain "%s" pattern to render service fqdn!'
+          path: annotations
+          value: {}

--- a/tests/tests/helm_lib_module_storage_class_test.yaml
+++ b/tests/tests/helm_lib_module_storage_class_test.yaml
@@ -1,0 +1,40 @@
+suite: helm_lib_module_storage_class_test definition
+templates:
+  - helm_lib_module_storage_class.yaml
+tests:
+  - it: should not contain default storage class annotation if no discovery.defaultStorageClass is set
+
+    set:
+      global:
+        discovery:
+          defaultStorageClass: ""
+
+    asserts:
+      - equal:
+          path: annotations
+          value: {}
+
+  - it: should contain default storage class annotation
+
+    set:
+      global:
+        discovery:
+          # set as in tests/templates/helm_lib_module_storage_class.yaml
+          defaultStorageClass: "cloud-provider-storageclass"
+
+    asserts:
+      - equal:
+          path: annotations["storageclass.kubernetes.io/is-default-class"]
+          value: "true"
+
+  # - it: should failed to render without "%s" pattern
+
+  #   set:
+  #     prefix: test
+  #     global:
+  #       modules:
+  #         publicDomainTemplate: .com
+
+  #   asserts:
+  #     - failedTemplate:
+  #         errorMessage: 'Error!!! global.modules.publicDomainTemplate must contain "%s" pattern to render service fqdn!'


### PR DESCRIPTION
Part of [PR9591](https://github.com/deckhouse/deckhouse/pull/9591)

Default storage class should be assigned only via `global.defaultClusterStorageClass` value. Not via helm's annotation from cloud-providers.

`cloudProvider.internal.defaultStorageClass` removed from cloud-providers modules in [PR9591](https://github.com/deckhouse/deckhouse/pull/9591)