### PR TITLE
Fix ToBeDeletedTaint on csi-node

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.37.0
+version: 1.37.1
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_node_affinity.tpl
+++ b/charts/helm_lib/templates/_node_affinity.tpl
@@ -243,7 +243,6 @@ tolerations:
 {{- define "_helm_lib_additional_tolerations_no_csi" }}
 - key: ToBeDeletedTaint
   operator: "Exists"
-  effect: "NoSchedule"
 - key: node.deckhouse.io/csi-not-bootstrapped
   operator: "Exists"
   effect: "NoSchedule"


### PR DESCRIPTION
Removed unnecessary `NoSchedule` effect introduced in 1.36