### PR TITLE
Bump version

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.44.5
+version: 1.44.6
 description: "Helm utils template definitions for Deckhouse modules."


### PR DESCRIPTION
In case of https://github.com/deckhouse/lib-helm/pull/99 was not builded into release, we need to bump version to fix it.