### PR TITLE
delete seccompProfile in old security_context define

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.63.3
+version: 1.63.4
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_security_context.tpl
+++ b/charts/helm_lib/templates/_module_security_context.tpl
@@ -8,8 +8,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: {{ index . 1 }}
   runAsGroup: {{ index . 2 }}
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_nobody" . }} */ -}}
@@ -20,8 +18,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 65534
   runAsGroup: 65534
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs" . }} */ -}}
@@ -33,8 +29,6 @@ securityContext:
   runAsUser: 65534
   runAsGroup: 65534
   fsGroup: 65534
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . }} */ -}}
@@ -45,8 +39,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 64535
   runAsGroup: 64535
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . }} */ -}}
@@ -58,8 +50,6 @@ securityContext:
   runAsUser: 64535
   runAsGroup: 64535
   fsGroup: 64535
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . }} */ -}}
@@ -105,8 +95,6 @@ securityContext:
   runAsUser:   {{ $uid }}
   runAsGroup:  {{ $uid }}
   runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 
@@ -118,8 +106,6 @@ securityContext:
   runAsNonRoot: false
   runAsUser: 0
   runAsGroup: 0
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_runtime_default" . }} */ -}}
@@ -148,8 +134,6 @@ securityContext:
   seLinuxOptions:
     level: 's0'
     type: 'spc_t'
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_read_only_root_filesystem" . }} */ -}}
@@ -159,8 +143,6 @@ securityContext:
 securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_privileged" . }} */ -}}
@@ -168,8 +150,6 @@ securityContext:
 {{- define "helm_lib_module_container_security_context_privileged" -}}
 securityContext:
   privileged: true
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_escalated_sys_admin_privileged" . }} */ -}}
@@ -182,8 +162,6 @@ securityContext:
     add:
     - SYS_ADMIN
   privileged: true
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . }} */ -}}
@@ -193,8 +171,6 @@ securityContext:
 securityContext:
   privileged: true
   readOnlyRootFilesystem: true
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . }} */ -}}
@@ -207,8 +183,6 @@ securityContext:
   capabilities:
     drop:
     - ALL
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add"  (list . (list "KILL" "SYS_PTRACE")) }} */ -}}
@@ -236,8 +210,6 @@ securityContext:
     drop:
     - ALL
     add: {{ index . 1 | toJson }}
-  seccompProfile:
-    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_capabilities_drop_all_and_run_as_user_custom" (list . 1000 1000) }} */ -}}

--- a/tests/tests/helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux_test.yaml
+++ b/tests/tests/helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux_test.yaml
@@ -13,5 +13,3 @@ tests:
             seLinuxOptions:
               level: 's0'
               type: 'spc_t'
-            seccompProfile:
-              type: RuntimeDefault


### PR DESCRIPTION
Removed the addition of seccompProfile to old templates. Backward compatibility is broken. This means that it must be added to SYS_ADMIN where it was previously possible to do without it.