### PR TITLE
[feat] Add SPE to CAPI template

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.71.8
+version: 1.71.9
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -518,6 +518,7 @@ list:
  + vpaEnabled (optional, default: `false`) — enables VerticalPodAutoscaler rendering. 
  + vpaUpdateMode (optional, default: `"InPlaceOrRecreate"`) — VPA update mode. 
  + vpaMaxAllowed (optional, default: `{cpu: 50m, memory: 50Mi}`) — maximum resource values used in VPA policy. 
+ + securityPolicyExceptionEnabled (optional, default: `false`) — enables SecurityPolicyException rendering and adds the related pod label. 
 
 #### Usage
 

--- a/charts/helm_lib/templates/_capi_controller_manager.tpl
+++ b/charts/helm_lib/templates/_capi_controller_manager.tpl
@@ -57,6 +57,7 @@ periodSeconds: 10
 {{- /* + vpaEnabled (optional, default: `false`) — enables VerticalPodAutoscaler rendering. */ -}}
 {{- /* + vpaUpdateMode (optional, default: `"InPlaceOrRecreate"`) — VPA update mode. */ -}}
 {{- /* + vpaMaxAllowed (optional, default: `{cpu: 50m, memory: 50Mi}`) — maximum resource values used in VPA policy. */ -}}
+{{- /* + securityPolicyExceptionEnabled (optional, default: `false`) — enables SecurityPolicyException rendering and adds the related pod label. */ -}}
 {{- define "helm_lib_capi_controller_manager_manifests" -}}
   {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc. */ -}}
   {{- $config := index . 1 -}} {{- /* Configuration dict for the CAPI Controller Manager. */ -}}
@@ -90,6 +91,7 @@ periodSeconds: 10
   {{- $vpaEnabled := dig "vpaEnabled" false $config -}}
   {{- $vpaUpdateMode := dig "vpaUpdateMode" "InPlaceOrRecreate" $config -}}
   {{- $vpaMaxAllowed := dig "vpaMaxAllowed" (include "capi_controller_manager_max_allowed_resources" $context | fromYaml) $config -}}
+  {{- $securityPolicyExceptionEnabled := dig "securityPolicyExceptionEnabled" false $config }}
 
 {{- if and $vpaEnabled ($context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
@@ -217,4 +219,26 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+
+{{- if and $securityPolicyExceptionEnabled ($context.Values.global.enabledModules | has "admission-policy-engine-crd") }}
+{{- if $hostNetwork }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ $namespace }}
+spec:
+  {{- if $hostNetwork }}
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host network access for CAPI infrastructure controller manager.
+          The CAPI infrastructure controller manager requires host network access to continue infrastructure reconciliation even if the CNI or pod network is unavailable.
+  {{- end }}
+{{- end }}
+{{- end }}
+
 {{- end -}}

--- a/tests/tests/helm_lib_capi_controller_manager_test.yaml
+++ b/tests/tests/helm_lib_capi_controller_manager_test.yaml
@@ -752,3 +752,131 @@ tests:
           path: spec.template.spec.containers[0].resources.requests.cpu
       - notExists:
           path: spec.template.spec.containers[0].resources.requests.memory
+
+  - it: does not render SecurityPolicyException when securityPolicyExceptionEnabled is false
+    set:
+      global:
+        modules:
+          placement: {}
+        enabledModules:
+          - admission-policy-engine-crd
+        discovery:
+          d8SpecificNodeCountByRole: {}
+      _testvalues:
+        fullname: capz-controller-manager
+        image: controllerImage
+        capiProviderName: infrastructure-zvirt
+        securityPolicyExceptionEnabled: false
+        hostNetwork: true
+    asserts:
+      - not: true
+        containsDocument:
+          kind: SecurityPolicyException
+          apiVersion: deckhouse.io/v1alpha1
+
+  - it: does not render SecurityPolicyException when admission-policy-engine-crd module is not enabled
+    set:
+      global:
+        modules:
+          placement: {}
+        enabledModules: []
+        discovery:
+          d8SpecificNodeCountByRole: {}
+      _testvalues:
+        fullname: capz-controller-manager
+        image: controllerImage
+        capiProviderName: infrastructure-zvirt
+        securityPolicyExceptionEnabled: true
+        hostNetwork: true
+    asserts:
+      - not: true
+        containsDocument:
+          kind: SecurityPolicyException
+          apiVersion: deckhouse.io/v1alpha1
+
+  - it: does not render SecurityPolicyException when hostNetwork is false
+    set:
+      global:
+        modules:
+          placement: {}
+        enabledModules:
+          - admission-policy-engine-crd
+        discovery:
+          d8SpecificNodeCountByRole: {}
+      _testvalues:
+        fullname: capz-controller-manager
+        image: controllerImage
+        capiProviderName: infrastructure-zvirt
+        securityPolicyExceptionEnabled: true
+        hostNetwork: false
+    asserts:
+      - not: true
+        containsDocument:
+          kind: SecurityPolicyException
+          apiVersion: deckhouse.io/v1alpha1
+      - hasDocuments:
+          count: 2
+
+  - it: renders SecurityPolicyException with hostNetwork when enabled and module is present
+    set:
+      global:
+        modules:
+          placement: {}
+        enabledModules:
+          - admission-policy-engine-crd
+        discovery:
+          d8SpecificNodeCountByRole: {}
+      _testvalues:
+        fullname: capcd-controller-manager
+        image: controllerImage
+        capiProviderName: infrastructure-static
+        securityPolicyExceptionEnabled: true
+        hostNetwork: true
+    documentSelector:
+      path: kind
+      value: SecurityPolicyException
+    asserts:
+      - hasDocuments:
+          count: 3
+      - containsDocument:
+          kind: SecurityPolicyException
+          apiVersion: deckhouse.io/v1alpha1
+          name: capcd-controller-manager
+          namespace: d8-test-module
+      - equal:
+          path: metadata.name
+          value: capcd-controller-manager
+      - equal:
+          path: spec.network.hostNetwork.allowedValue
+          value: true
+      - matchRegex:
+          path: spec.network.hostNetwork.metadata.description
+          pattern: host network access
+      - notExists:
+          path: spec.securityContext
+      - notExists:
+          path: spec.volumes
+
+  - it: renders SecurityPolicyException in custom namespace
+    set:
+      global:
+        modules:
+          placement: {}
+        enabledModules:
+          - admission-policy-engine-crd
+        discovery:
+          d8SpecificNodeCountByRole: {}
+      _testvalues:
+        fullname: capcd-controller-manager
+        namespace: d8-cloud-provider-example
+        image: controllerImage
+        capiProviderName: infrastructure-static
+        securityPolicyExceptionEnabled: true
+        hostNetwork: true
+    documentSelector:
+      path: kind
+      value: SecurityPolicyException
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: d8-cloud-provider-example


### PR DESCRIPTION
## Description

Add SecurityPoliycException to CAPI controller manager

## Why do we need this and what problem does it solve?

This mechanism allows you to create specific exceptions for individual services and pods using SecurityPolicyException.

A hostNetwork parameter has been added to CAPI controller managers to ensure their functionality when the CNI is down. The pod security policy ([PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)) considers such settings to be too privileged and insecure. To ensure components can pass checks and be created, SecurityPolicyException handling has been added.