### PR TITLE
[fix] Add CSI liveness probe timeout

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.71.9
+version: 1.71.10
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_csi_controller.tpl
+++ b/charts/helm_lib/templates/_csi_controller.tpl
@@ -92,6 +92,7 @@ memory: 50Mi
   {{- $attacherTimeout := $config.attacherTimeout | default "600s" }}
   {{- $resizerTimeout := $config.resizerTimeout | default "600s" }}
   {{- $snapshotterTimeout := $config.snapshotterTimeout | default "600s" }}
+  {{- $livenessProbeTimeout := $config.livenessProbeTimeout | default "5s" }}
   {{- $provisionerWorkers := $config.provisionerWorkers | default "10" }}
   {{- $volumeNamePrefix := $config.volumeNamePrefix }}
   {{- $volumeNameUUIDLength := $config.volumeNameUUIDLength }}
@@ -465,6 +466,7 @@ spec:
         image: {{ $livenessprobeImage | quote }}
         args:
         - "--csi-address=$(ADDRESS)"
+        - "--probe-timeout={{ $livenessProbeTimeout }}"
   {{- if eq $csiControllerHostNetwork "true" }}
         - "--http-endpoint=$(HOST_IP):{{ $livenessProbePort }}"
   {{- else }}
@@ -512,6 +514,9 @@ spec:
           httpGet:
             path: /healthz
             port: {{ $livenessProbePort }}
+          initialDelaySeconds: 5
+          timeoutSeconds: {{ $livenessProbeTimeout }}
+
     {{- if $additionalControllerPorts }}
         ports:
         {{- $additionalControllerPorts | toYaml | nindent 8 }}

--- a/charts/helm_lib/templates/_csi_controller.tpl
+++ b/charts/helm_lib/templates/_csi_controller.tpl
@@ -92,7 +92,6 @@ memory: 50Mi
   {{- $attacherTimeout := $config.attacherTimeout | default "600s" }}
   {{- $resizerTimeout := $config.resizerTimeout | default "600s" }}
   {{- $snapshotterTimeout := $config.snapshotterTimeout | default "600s" }}
-  {{- $livenessProbeTimeout := $config.livenessProbeTimeout | default "5s" }}
   {{- $provisionerWorkers := $config.provisionerWorkers | default "10" }}
   {{- $volumeNamePrefix := $config.volumeNamePrefix }}
   {{- $volumeNameUUIDLength := $config.volumeNameUUIDLength }}
@@ -112,6 +111,8 @@ memory: 50Mi
   {{- $csiControllerHostNetwork := $config.csiControllerHostNetwork | default "true" }}
   {{- $csiControllerHostPID := $config.csiControllerHostPID | default "false" }}
   {{- $livenessProbePort := $config.livenessProbePort | default 9808 }}
+  {{- $livenessProbeTimeoutSeconds := $config.livenessProbeTimeoutSeconds | default 5 }}
+  {{- $livenessProbeInitialDelaySeconds := $config.livenessProbeInitialDelaySeconds | default 5 }}
   {{- $initContainers := $config.initContainers }}
   {{- $customNodeSelector := $config.customNodeSelector }}
   {{- $additionalPullSecrets := $config.additionalPullSecrets }}
@@ -466,7 +467,7 @@ spec:
         image: {{ $livenessprobeImage | quote }}
         args:
         - "--csi-address=$(ADDRESS)"
-        - "--probe-timeout={{ $livenessProbeTimeout }}"
+        - "--probe-timeout={{ $livenessProbeTimeoutSeconds }}s"
   {{- if eq $csiControllerHostNetwork "true" }}
         - "--http-endpoint=$(HOST_IP):{{ $livenessProbePort }}"
   {{- else }}
@@ -514,8 +515,8 @@ spec:
           httpGet:
             path: /healthz
             port: {{ $livenessProbePort }}
-          initialDelaySeconds: 5
-          timeoutSeconds: {{ $livenessProbeTimeout }}
+          initialDelaySeconds: {{ $livenessProbeInitialDelaySeconds }}
+          timeoutSeconds: {{ $livenessProbeTimeoutSeconds }}
 
     {{- if $additionalControllerPorts }}
         ports:

--- a/tests/tests/helm_lib_csi_controller_test.yaml
+++ b/tests/tests/helm_lib_csi_controller_test.yaml
@@ -153,3 +153,47 @@ tests:
 
       - notExists:
           path: spec.template.spec.dnsPolicy
+
+  - it: renders csi controller manifests with liveness probe timeout
+
+    set:
+      global:
+        modules:
+          placement: {}
+        modulesImages:
+          registry:
+            base: "deckhouse.io/deckhouse/ce"
+          digests:
+            common:
+              csiExternalAttacher125: csiControllerAttacher125
+              csiExternalProvisioner125: csiControllerProvisioner125
+              csiExternalResizer125: csiControllerResizer125
+              csiExternalSnapshotter125: csiControllerSnapshotter125
+              csiLivenessprobe125: csiLivenessProbe125
+        discovery:
+          kubernetesVersion: "1.25"
+          d8SpecificNodeCountByRole: {}
+      _testvalues:
+        controllerImage: controllerImage
+        dnsPolicy: Default
+        livenessProbeTimeout: "10s"
+    documentSelector:
+      path: kind
+      value: Deployment
+
+    asserts:
+      - hasDocuments:
+          count: 2
+
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: csi-controller
+          namespace: d8-test-module
+
+      - equal:
+          path: spec.template.spec.containers[4].args[1]
+          value: "--probe-timeout=10s"
+      - equal:
+          path: spec.template.spec.containers[5].livenessProbe.timeoutSeconds
+          value: "10s"

--- a/tests/tests/helm_lib_csi_controller_test.yaml
+++ b/tests/tests/helm_lib_csi_controller_test.yaml
@@ -176,7 +176,8 @@ tests:
       _testvalues:
         controllerImage: controllerImage
         dnsPolicy: Default
-        livenessProbeTimeout: "10s"
+        livenessProbeInitialDelaySeconds: 10
+        livenessProbeTimeoutSeconds: 10
     documentSelector:
       path: kind
       value: Deployment
@@ -195,5 +196,8 @@ tests:
           path: spec.template.spec.containers[4].args[1]
           value: "--probe-timeout=10s"
       - equal:
+          path: spec.template.spec.containers[5].livenessProbe.initialDelaySeconds
+          value: 10
+      - equal:
           path: spec.template.spec.containers[5].livenessProbe.timeoutSeconds
-          value: "10s"
+          value: 10


### PR DESCRIPTION
## Description

Add liveness probe timeout for controller and livenessprobe container in CSI controller deployment

## Why do we need it, and what problem does it solve?

Currently, for the CSI controller, liveness probe has a timeout of 1 second. The controller container always has time to respond, but sometimes a successful response doesn't make it to the livenessprobe container and back to the client.