### PR TITLE
Add extra domains for helm_lib_envs_for_proxy 

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.71.10
+version: 1.71.11
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -681,11 +681,13 @@ list:
 
 #### Usage
 
-`{{ include "helm_lib_envs_for_proxy" . }} `
+`{{ include "helm_lib_envs_for_proxy" . }} or {{ include "helm_lib_envs_for_proxy" (list . (list "extra1" "extra2")) }} `
 
 #### Arguments
 
+list:
 -  Template context with .Values, .Chart, etc 
+-  List of additional NO_PROXY entries (optional) 
 
 ## High Availability
 

--- a/charts/helm_lib/templates/_envs_for_proxy.tpl
+++ b/charts/helm_lib/templates/_envs_for_proxy.tpl
@@ -1,8 +1,18 @@
-{{- /* Usage: {{ include "helm_lib_envs_for_proxy" . }} */ -}}
+{{- /* Usage: {{ include "helm_lib_envs_for_proxy" . }} or {{ include "helm_lib_envs_for_proxy" (list . (list "extra1" "extra2")) }} */ -}}
 {{- /* Add HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables for container */ -}}
 {{- /* depends on [proxy settings](https://deckhouse.io/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-proxy) */ -}}
 {{- define "helm_lib_envs_for_proxy" }}
-  {{- $context := . -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- /* List of additional NO_PROXY entries (optional) */ -}}
+  {{- $context := . -}}
+  {{- $extraNoProxy := list -}}
+
+  {{- /* If a list is passed, then the first element is the context, and the second is the extraNoProxy list. */ -}}
+  {{- if kindIs "slice" . }}
+    {{- $context = index . 0 -}}
+    {{- $extraNoProxy = index . 1 -}}
+  {{- end }}
+
   {{- if $context.Values.global.clusterConfiguration }}
     {{- if $context.Values.global.clusterConfiguration.proxy }}
       {{- if $context.Values.global.clusterConfiguration.proxy.httpProxy }}
@@ -20,6 +30,9 @@
       {{- $noProxy := list "127.0.0.1" "169.254.169.254" "registry.d8-system.svc" $context.Values.global.clusterConfiguration.clusterDomain $context.Values.global.clusterConfiguration.podSubnetCIDR $context.Values.global.clusterConfiguration.serviceSubnetCIDR }}
       {{- if $context.Values.global.clusterConfiguration.proxy.noProxy }}
         {{- $noProxy = concat $noProxy $context.Values.global.clusterConfiguration.proxy.noProxy }}
+      {{- end }}
+      {{- if $extraNoProxy }}
+        {{- $noProxy = concat $noProxy $extraNoProxy }}
       {{- end }}
 - name: NO_PROXY
   value: {{ $noProxy | join "," | quote }}

--- a/tests/templates/helm_lib_envs_for_proxy.yaml
+++ b/tests/templates/helm_lib_envs_for_proxy.yaml
@@ -1,2 +1,4 @@
 proxyEnvs:
 {{ include "helm_lib_envs_for_proxy" . }}
+proxyEnvsWithExtra:
+{{ include "helm_lib_envs_for_proxy" (list . (list "extra1" "extra2")) }}

--- a/tests/tests/helm_lib_envs_for_proxy_test.yaml
+++ b/tests/tests/helm_lib_envs_for_proxy_test.yaml
@@ -51,6 +51,18 @@ tests:
       - equal:
           path: "proxyEnvs[5].value"
           value: "127.0.0.1,169.254.169.254,registry.d8-system.svc,cluster.local,10.0.0.0/16,10.1.0.0/16,example.com"
+      - equal:
+          path: "proxyEnvsWithExtra[4].name"
+          value: "NO_PROXY"
+      - equal:
+          path: "proxyEnvsWithExtra[4].value"
+          value: "127.0.0.1,169.254.169.254,registry.d8-system.svc,cluster.local,10.0.0.0/16,10.1.0.0/16,example.com,extra1,extra2"
+      - equal:
+          path: "proxyEnvsWithExtra[5].name"
+          value: "no_proxy"
+      - equal:
+          path: "proxyEnvsWithExtra[5].value"
+          value: "127.0.0.1,169.254.169.254,registry.d8-system.svc,cluster.local,10.0.0.0/16,10.1.0.0/16,example.com,extra1,extra2"
 
   - it: should render proxy env vars with only http proxy
     set:
@@ -86,6 +98,18 @@ tests:
       - equal:
           path: "proxyEnvs[3].value"
           value: "127.0.0.1,169.254.169.254,registry.d8-system.svc,cluster.local,10.0.0.0/16,10.1.0.0/16"
+      - equal:
+          path: "proxyEnvsWithExtra[2].name"
+          value: "NO_PROXY"
+      - equal:
+          path: "proxyEnvsWithExtra[2].value"
+          value: "127.0.0.1,169.254.169.254,registry.d8-system.svc,cluster.local,10.0.0.0/16,10.1.0.0/16,extra1,extra2"
+      - equal:
+          path: "proxyEnvsWithExtra[3].name"
+          value: "no_proxy"
+      - equal:
+          path: "proxyEnvsWithExtra[3].value"
+          value: "127.0.0.1,169.254.169.254,registry.d8-system.svc,cluster.local,10.0.0.0/16,10.1.0.0/16,extra1,extra2"
 
   - it: should not render proxy env vars when no proxy configured
     set:
@@ -97,3 +121,5 @@ tests:
     asserts:
       - isEmpty:
           path: "proxyEnvs"
+      - isEmpty:
+          path: "proxyEnvsWithExtra"


### PR DESCRIPTION
Description
Adding the ability to helm_lib_envs_for_proxy to add extra domains

Why do we need it, and what problem does it solve?
The subnets podSubnetCIDR, serviceSubnetCIDR and the clusterDomain domain are added to NoProxy automatically. But stronghold and secrets-stora-integration go by the “short name of the service", because it is in this name that the certificate is issued. It's made for that. in order not to recreate the certificate when changing clusterDomain.
This ability allow to add custom services for include in noproxy list