### PR TITLE
[feat] Add user-authz ClusterRole templates for cloud providers

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.71.11
+version: 1.71.12
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -39,6 +39,8 @@
 | **Cloud Data Discoverer** |
 | [helm_lib_cloud_data_discoverer_manifests](#helm_lib_cloud_data_discoverer_manifests) |
 | [helm_lib_cloud_data_discoverer_pod_monitor](#helm_lib_cloud_data_discoverer_pod_monitor) |
+| **Cloud Provider User Authz Roles** |
+| [helm_lib_cloud_provider_user_authz_cluster_roles](#helm_lib_cloud_provider_user_authz_cluster_roles) |
 | **Csi Controller** |
 | [helm_lib_csi_image_with_common_fallback](#helm_lib_csi_image_with_common_fallback) |
 | **Dns Policy** |
@@ -630,6 +632,24 @@ list:
 #### Usage
 
 `{{ include "helm_lib_cloud_data_discoverer_pod_monitor" (list . $config) }} `
+
+
+## Cloud Provider User Authz Roles
+
+### helm_lib_cloud_provider_user_authz_cluster_roles
+
+ Renders user-authz ClusterRoles for provider-specific cloud resources. 
+ Includes User and ClusterAdmin ClusterRoles. 
+ Supported configuration parameters: 
+ + providerName (required) — provider name segment used in ClusterRole names. 
+ + instanceClassResource (required) — Deckhouse instance class resource name granted by the rules. 
+ + capiResources (optional, default: `[]`) — CAPI infrastructure resource names granted by the rules. 
+ + additionalUserRules (optional, default: `[]`) — extra rules appended to the User ClusterRole. 
+ + additionalClusterAdminRules (optional, default: `[]`) — extra rules appended to the ClusterAdmin ClusterRole. 
+
+#### Usage
+
+`{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $config) }} `
 
 
 ## Csi Controller

--- a/charts/helm_lib/templates/_cloud_provider_user_authz_roles.tpl
+++ b/charts/helm_lib/templates/_cloud_provider_user_authz_roles.tpl
@@ -1,0 +1,83 @@
+{{- /* Usage: {{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $config) }} */ -}}
+{{- /* Renders user-authz ClusterRoles for provider-specific cloud resources. */ -}}
+{{- /* Includes User and ClusterAdmin ClusterRoles. */ -}}
+{{- /* Supported configuration parameters: */ -}}
+{{- /* + providerName (required) — provider name segment used in ClusterRole names. */ -}}
+{{- /* + instanceClassResource (required) — Deckhouse instance class resource name granted by the rules. */ -}}
+{{- /* + capiResources (optional, default: `[]`) — CAPI infrastructure resource names granted by the rules. */ -}}
+{{- /* + additionalUserRules (optional, default: `[]`) — extra rules appended to the User ClusterRole. */ -}}
+{{- /* + additionalClusterAdminRules (optional, default: `[]`) — extra rules appended to the ClusterAdmin ClusterRole. */ -}}
+{{- define "helm_lib_cloud_provider_user_authz_cluster_roles" -}}
+  {{- $context := index . 0 -}}
+  {{- $config := index . 1 -}}
+  {{- $providerName := required "helm_lib_cloud_provider_user_authz_cluster_roles: providerName is required" (get $config "providerName") -}}
+  {{- $instanceClassResource := required "helm_lib_cloud_provider_user_authz_cluster_roles: instanceClassResource is required" (get $config "instanceClassResource") -}}
+  {{- $capiResources := dig "capiResources" (list) $config -}}
+  {{- $additionalUserRules := dig "additionalUserRules" (list) $config -}}
+  {{- $additionalClusterAdminRules := dig "additionalClusterAdminRules" (list) $config -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:{{ $providerName }}:user
+  {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - {{ $instanceClassResource }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- if $capiResources }}
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  {{- range $capiResources }}
+  - {{ . }}
+  {{- end }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+{{- with $additionalUserRules }}
+{{ toYaml . }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:{{ $providerName }}:cluster-admin
+  {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - {{ $instanceClassResource }}
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+{{- if $capiResources }}
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  {{- range $capiResources }}
+  - {{ . }}
+  {{- end }}
+  verbs:
+  - patch
+  - update
+{{- end }}
+{{- with $additionalClusterAdminRules }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}

--- a/tests/templates/helm_lib_cloud_provider_user_authz_cluster_roles.yaml
+++ b/tests/templates/helm_lib_cloud_provider_user_authz_cluster_roles.yaml
@@ -1,0 +1,1 @@
+{{ include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . .Values._testvalues) }}

--- a/tests/tests/helm_lib_cloud_provider_user_authz_cluster_roles_test.yaml
+++ b/tests/tests/helm_lib_cloud_provider_user_authz_cluster_roles_test.yaml
@@ -1,0 +1,205 @@
+suite: helm_lib_cloud_provider_user_authz_cluster_roles definition
+templates:
+  - helm_lib_cloud_provider_user_authz_cluster_roles.yaml
+
+tests:
+  - it: renders VCD user-authz ClusterRoles with CAPI resources and extra rules
+    set:
+      _testvalues:
+        providerName: vcd
+        instanceClassResource: vcdinstanceclasses
+        capiResources:
+          - vcdclusters
+          - vcdclustertemplates
+          - vcdmachines
+          - vcdmachinetemplates
+        additionalUserRules:
+          - apiGroups:
+              - deckhouse.io
+            resources:
+              - vcdaffinityrules
+            verbs:
+              - get
+              - list
+              - watch
+        additionalClusterAdminRules:
+          - apiGroups:
+              - deckhouse.io
+            resources:
+              - vcdaffinityrules
+            verbs:
+              - patch
+              - update
+    documentSelector:
+      path: metadata.name
+      value: d8:user-authz:vcd:user
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: d8:user-authz:vcd:user
+      - equal:
+          path: metadata.annotations["user-authz.deckhouse.io/access-level"]
+          value: User
+      - equal:
+          path: rules[0]
+          value:
+            apiGroups:
+              - deckhouse.io
+            resources:
+              - vcdinstanceclasses
+            verbs:
+              - get
+              - list
+              - watch
+      - equal:
+          path: rules[1]
+          value:
+            apiGroups:
+              - infrastructure.cluster.x-k8s.io
+            resources:
+              - vcdclusters
+              - vcdclustertemplates
+              - vcdmachines
+              - vcdmachinetemplates
+            verbs:
+              - get
+              - list
+              - watch
+      - equal:
+          path: rules[2]
+          value:
+            apiGroups:
+              - deckhouse.io
+            resources:
+              - vcdaffinityrules
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: renders VCD cluster-admin ClusterRole with CAPI resources and extra rules
+    set:
+      _testvalues:
+        providerName: vcd
+        instanceClassResource: vcdinstanceclasses
+        capiResources:
+          - vcdclusters
+          - vcdclustertemplates
+          - vcdmachines
+          - vcdmachinetemplates
+        additionalClusterAdminRules:
+          - apiGroups:
+              - deckhouse.io
+            resources:
+              - vcdaffinityrules
+            verbs:
+              - patch
+              - update
+    documentSelector:
+      path: metadata.name
+      value: d8:user-authz:vcd:cluster-admin
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: d8:user-authz:vcd:cluster-admin
+      - equal:
+          path: metadata.annotations["user-authz.deckhouse.io/access-level"]
+          value: ClusterAdmin
+      - equal:
+          path: rules[0]
+          value:
+            apiGroups:
+              - deckhouse.io
+            resources:
+              - vcdinstanceclasses
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - patch
+              - update
+      - equal:
+          path: rules[1]
+          value:
+            apiGroups:
+              - infrastructure.cluster.x-k8s.io
+            resources:
+              - vcdclusters
+              - vcdclustertemplates
+              - vcdmachines
+              - vcdmachinetemplates
+            verbs:
+              - patch
+              - update
+      - equal:
+          path: rules[2]
+          value:
+            apiGroups:
+              - deckhouse.io
+            resources:
+              - vcdaffinityrules
+            verbs:
+              - patch
+              - update
+
+  - it: renders OpenStack user ClusterRole without CAPI resources
+    set:
+      _testvalues:
+        providerName: openstack
+        instanceClassResource: openstackinstanceclasses
+    documentSelector:
+      path: metadata.name
+      value: d8:user-authz:openstack:user
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: d8:user-authz:openstack:user
+      - equal:
+          path: rules[0]
+          value:
+            apiGroups:
+              - deckhouse.io
+            resources:
+              - openstackinstanceclasses
+            verbs:
+              - get
+              - list
+              - watch
+      - notExists:
+          path: rules[1]
+
+  - it: renders OpenStack cluster-admin ClusterRole without CAPI resources
+    set:
+      _testvalues:
+        providerName: openstack
+        instanceClassResource: openstackinstanceclasses
+    documentSelector:
+      path: metadata.name
+      value: d8:user-authz:openstack:cluster-admin
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: d8:user-authz:openstack:cluster-admin
+      - equal:
+          path: rules[0]
+          value:
+            apiGroups:
+              - deckhouse.io
+            resources:
+              - openstackinstanceclasses
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - patch
+              - update
+      - notExists:
+          path: rules[1]


### PR DESCRIPTION
## Description

Added a new helper `helm_lib_cloud_provider_user_authz_cluster_roles` for rendering `User` and `ClusterAdmin` ClusterRole for cloud-provider modules. Updated README, bumped version and added unit tests.

## Why do we need it, and what problem does it solve?

This allows you to reuse the common RBAC template for provider-specific `user-authz` roles and avoid duplication in cloud-provider modules.