### PR TITLE
Change VPA UpdateMode

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.71.12
+version: 1.72.0
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_csi_controller.tpl
+++ b/charts/helm_lib/templates/_csi_controller.tpl
@@ -150,7 +150,7 @@ spec:
     kind: Deployment
     name: {{ $fullname }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     - containerName: "provisioner"

--- a/charts/helm_lib/templates/_csi_node.tpl
+++ b/charts/helm_lib/templates/_csi_node.tpl
@@ -56,7 +56,7 @@ spec:
     kind: DaemonSet
     name: {{ $fullname }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     {{- if $additionalNodeVPA }}

--- a/tests/templates/helm_lib_resources_management_vpa_spec.yaml
+++ b/tests/templates/helm_lib_resources_management_vpa_spec.yaml
@@ -1,3 +1,3 @@
-{{- $config := dict "mode" "VPA" "vpa" (dict "mode" "Auto" "cpu" (dict "max" "500m" "min" "100m") "memory" (dict "max" "1Gi" "min" "128Mi")) }}
+{{- $config := dict "mode" "VPA" "vpa" (dict "mode" "InPlaceOrRecreate" "cpu" (dict "max" "500m" "min" "100m") "memory" (dict "max" "1Gi" "min" "128Mi")) }}
 {{- $result := include "helm_lib_resources_management_vpa_spec" (list "apps/v1" "Deployment" "test-deployment" "test-container" $config) }}
 result: {{ $result | toString | quote }}

--- a/tests/tests/helm_lib_resources_management_vpa_spec_test.yaml
+++ b/tests/tests/helm_lib_resources_management_vpa_spec_test.yaml
@@ -18,4 +18,4 @@ tests:
           pattern: "name: test-deployment"
       - matchRegex:
           path: result
-          pattern: 'updateMode: "Auto"'
+          pattern: 'updateMode: "InPlaceOrRecreate"'


### PR DESCRIPTION
Change CPA UpdateMode for CSI controllers.
UpdateMode: "Auto" is deprecated and generates a lot of spam in the logs
```
Running helm upgrade for release
"Warning: UpdateMode "Auto" is deprecated and will be removed in a future API version. Use explicit update modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead. See https://github.com/kubernetes/autoscaler/issues/8424 for more details." (warnings.go:110)
"Warning: UpdateMode "Auto" is deprecated and will be removed in a future API version. Use explicit update modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead. See https://github.com/kubernetes/autoscaler/issues/8424 for more details." (warnings.go:110)
```

Change to the `InPlaceOrRecreate` is safe, because `Auto` mode is equal to `Recreate`

### Breaking Changes ###
Compatible only with the Deckhouse version 1.75+