### PR TITLE
set volume-expansion-mode to online

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.0
+version: 1.72.1
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_storage_class.tpl
+++ b/charts/helm_lib/templates/_module_storage_class.tpl
@@ -14,18 +14,8 @@
     {{- end }}
   {{- end }}
 
-  {{- $volume_expansion_mode_online := false -}}
-  {{- range $module_name := list "cloud-provider-yandex"}}
-    {{- if has $module_name $context.Values.global.enabledModules }}
-      {{- $volume_expansion_mode_online = true }}
-    {{- end }}
-  {{- end }}
-
   {{- if $volume_expansion_mode_offline }}
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
-  {{- else if $volume_expansion_mode_online }}
-    {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "online" }}
-  {{- end }}
 
   {{- if $context.Values.global.discovery.defaultStorageClass }}
     {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}

--- a/charts/helm_lib/templates/_module_storage_class.tpl
+++ b/charts/helm_lib/templates/_module_storage_class.tpl
@@ -8,14 +8,23 @@
   {{- $annotations := dict -}}
 
   {{- $volume_expansion_mode_offline := false -}}
-  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-yandex" "cloud-provider-vsphere" "cloud-provider-vcd"}}
+  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-vsphere" "cloud-provider-vcd"}}
     {{- if has $module_name $context.Values.global.enabledModules }}
       {{- $volume_expansion_mode_offline = true }}
     {{- end }}
   {{- end }}
 
+  {{- $volume_expansion_mode_online := false -}}
+  {{- range $module_name := list "cloud-provider-yandex"}}
+    {{- if has $module_name $context.Values.global.enabledModules }}
+      {{- $volume_expansion_mode_online = true }}
+    {{- end }}
+  {{- end }}
+
   {{- if $volume_expansion_mode_offline }}
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
+  {{- else if $volume_expansion_mode_online }}
+    {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "online" }}
   {{- end }}
 
   {{- if $context.Values.global.discovery.defaultStorageClass }}

--- a/charts/helm_lib/templates/_module_storage_class.tpl
+++ b/charts/helm_lib/templates/_module_storage_class.tpl
@@ -16,7 +16,7 @@
 
   {{- if $volume_expansion_mode_offline }}
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
-
+  {{- end }}
   {{- if $context.Values.global.discovery.defaultStorageClass }}
     {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
       {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}

--- a/charts/helm_lib/templates/_module_storage_class.tpl
+++ b/charts/helm_lib/templates/_module_storage_class.tpl
@@ -17,6 +17,7 @@
   {{- if $volume_expansion_mode_offline }}
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
   {{- end }}
+  
   {{- if $context.Values.global.discovery.defaultStorageClass }}
     {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
       {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}


### PR DESCRIPTION
## Description

Remove `cloud-provider-yandex` from the `offline` volume expansion list and add it
to an explicit `online` list in `helm_lib_module_storage_class_annotations`.

## Why do we need it, and what problem does it solve?

StorageClasses for `cloud-provider-yandex` were incorrectly annotated with
`storageclass.deckhouse.io/volume-expansion-mode: offline`, implying that PVC resize
requires pod restart.
