### PR TITLE
add seccomp profile to iptables wrapper init container

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.1
+version: 1.72.2
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_init_container.tpl
+++ b/charts/helm_lib/templates/_module_init_container.tpl
@@ -74,6 +74,8 @@
     runAsNonRoot: false
     runAsUser: 0
     runAsGroup: 0
+    seccompProfile:
+      type: RuntimeDefault
   image: {{ include "helm_lib_module_image" (list $context  "iptablesWrapperInit") }}
   command:
   - /bin/bash

--- a/tests/tests/helm_lib_module_init_container_test.yaml
+++ b/tests/tests/helm_lib_module_init_container_test.yaml
@@ -153,6 +153,8 @@ tests:
                 runAsGroup: 0
                 runAsNonRoot: false
                 runAsUser: 0
+                seccompProfile:
+                  type: RuntimeDefault
               volumeMounts:
                 - mountPath: /sbin
                   name: sbin
@@ -202,6 +204,8 @@ tests:
                 runAsGroup: 0
                 runAsNonRoot: false
                 runAsUser: 0
+                seccompProfile:
+                  type: RuntimeDefault
               volumeMounts:
                 - mountPath: /sbin
                   name: sbin


### PR DESCRIPTION
Adds seccomp profile setting to the securityContext of the iptables-wrapper-init container.