### PR TITLE
csi-node: add optional startupProbe for slow-starting drivers

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.4
+version: 1.72.5
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_csi_node.tpl
+++ b/charts/helm_lib/templates/_csi_node.tpl
@@ -36,6 +36,7 @@ memory: 25Mi
   {{- $additionalCsiNodePodAnnotations := $config.additionalCsiNodePodAnnotations | default false }}
   {{- $csiNodeHostNetwork := $config.csiNodeHostNetwork | default "true" }}
   {{- $csiNodeHostPID := $config.csiNodeHostPID | default "false" }}
+  {{- $startupProbeFailureThreshold := $config.startupProbeFailureThreshold | default 0 }}
   {{- $dnsPolicy := $config.dnsPolicy | default "ClusterFirstWithHostNet" }}
   {{- $securityPolicyExceptionEnabled := $config.securityPolicyExceptionEnabled | default false }}
   {{- $kubernetesSemVer := semver $context.Values.global.discovery.kubernetesVersion }}
@@ -215,6 +216,15 @@ spec:
             path: /healthz
             port: {{ $livenessProbePort }}
           initialDelaySeconds: 5
+          timeoutSeconds: 5
+      {{- end }}
+      {{- if and $livenessProbePort $startupProbeFailureThreshold }}
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: {{ $livenessProbePort }}
+          periodSeconds: 10
+          failureThreshold: {{ $startupProbeFailureThreshold }}
           timeoutSeconds: 5
       {{- end }}
         volumeMounts:


### PR DESCRIPTION
## Description

Add a `startupProbeFailureThreshold` config parameter to the CSI node
DaemonSet template (`_csi_node.tpl`). When set to a positive integer, a
Kubernetes `startupProbe` is rendered on the `node` container using the
same `/healthz` HTTP endpoint as the existing liveness probe.

While the startup probe is active the kubelet suspends liveness checks,
giving the driver enough time to finish initialisation before the pod is
considered unhealthy.

## Why do we need it, and what problem does it solve?

CSI drivers that perform device cleanup at startup (e.g. Huawei eSDK
garbage collector, `triggerGarbageCollector()`) can block the gRPC
server for up to 240 seconds. The existing `livenessProbe`
(`initialDelaySeconds: 5`, default `failureThreshold: 3`,
`periodSeconds: 10`) kills the pod after ~35 s, well before startup
completes. This creates an infinite crash loop where stale multipath
maps are never cleaned and trigger the next restart.

## What is the expected result?

Modules that set `startupProbeFailureThreshold` in their CSI node config
(e.g. `30` → 300 s max startup time) will have a `startupProbe` rendered
in the DaemonSet manifest. Modules that do not set the parameter are
unaffected (backward compatible, defaults to `0` / disabled).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.