### PR TITLE
add hostPorts to SecurityPolicyException for CAPI controllers with hostNetwork

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.2
+version: 1.72.3
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_capi_controller_manager.tpl
+++ b/charts/helm_lib/templates/_capi_controller_manager.tpl
@@ -229,15 +229,20 @@ metadata:
   name: {{ $fullname }}
   namespace: {{ $namespace }}
 spec:
-  {{- if $hostNetwork }}
   network:
+    {{- if $additionalPorts }}
+    hostPorts:
+      {{- range $additionalPorts }}
+      - port: {{ .containerPort }}
+        protocol: {{ .protocol | default "TCP" }}
+      {{- end }}
+    {{- end }}
     hostNetwork:
       allowedValue: true
       metadata:
         description: |
           Allow host network access for CAPI infrastructure controller manager.
           The CAPI infrastructure controller manager requires host network access to continue infrastructure reconciliation even if the CNI or pod network is unavailable.
-  {{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
When a CAPI infrastructure controller manager uses hostNetwork, container ports are accessible on the host network and are treated as hostPorts by the admission-policy-engine security policy check. The generated SecurityPolicyException only allowed hostNetwork but did not list the hostPorts, causing pod creation to fail with "hostPorts are not allowed, policy allows: []".
