### PR TITLE
Revert "[feature] Add appArmor config values in securityContext (#200)"

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.6
+version: 1.72.5
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.5
+version: 1.72.7
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -311,12 +311,10 @@ list:
  .uid  – int, runAsUser/runAsGroup (default 64535) 
  .runAsNonRoot   – bool, run as Deckhouse user when true, root when false (default true) 
  .seccompProfile  – bool, disable seccompProfile when false (default true) 
- .appArmorProfile – string, appArmorProfile.type, set to empty string to disable (default RuntimeDefault) 
- .appArmorProfileLocalhost – string, appArmorProfile.localhostProfile, used only when appArmorProfile is "Localhost" (default empty) 
 
 #### Usage
 
-`include "helm_lib_application_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true "appArmorProfile" "Localhost" "appArmorProfileLocalhost" "k8s-apparmor-example-deny-write") `
+`include "helm_lib_application_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true) `
 
 
 
@@ -1251,12 +1249,10 @@ list:
  .uid  – int, runAsUser/runAsGroup (default 64535) 
  .runAsNonRoot   – bool, run as Deckhouse user when true, root when false (default true) 
  .seccompProfile  – bool, disable seccompProfile when false (default true) 
- .appArmorProfile – string, appArmorProfile.type, set to empty string to disable (default RuntimeDefault) 
- .appArmorProfileLocalhost – string, appArmorProfile.localhostProfile, used only when appArmorProfile is "Localhost" (default empty) 
 
 #### Usage
 
-`include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true "appArmorProfile" "Localhost" "appArmorProfileLocalhost" "k8s-apparmor-example-deny-write") `
+`include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true) `
 
 
 

--- a/charts/helm_lib/templates/_application_security_context.tpl
+++ b/charts/helm_lib/templates/_application_security_context.tpl
@@ -76,9 +76,7 @@ securityContext:
 {{- /* .uid  – int, runAsUser/runAsGroup (default 64535) */ -}}
 {{- /* .runAsNonRoot   – bool, run as Deckhouse user when true, root when false (default true) */ -}}
 {{- /* .seccompProfile  – bool, disable seccompProfile when false (default true) */ -}}
-{{- /* .appArmorProfile – string, appArmorProfile.type, set to empty string to disable (default RuntimeDefault) */ -}}
-{{- /* .appArmorProfileLocalhost – string, appArmorProfile.localhostProfile, used only when appArmorProfile is "Localhost" (default empty) */ -}}
-{{- /* Usage: include "helm_lib_application_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true "appArmorProfile" "Localhost" "appArmorProfileLocalhost" "k8s-apparmor-example-deny-write") */ -}}
+{{- /* Usage: include "helm_lib_application_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true) */ -}}
 {{- define "helm_lib_application_container_security_context_pss_restricted_flexible" -}}
 {{- $ro := true -}}
 {{- if hasKey . "ro" -}}
@@ -87,14 +85,6 @@ securityContext:
 {{- $seccompProfile := true -}}
 {{- if hasKey . "seccompProfile" -}}
   {{- $seccompProfile = .seccompProfile -}}
-{{- end -}}
-{{- $appArmorProfile := "RuntimeDefault" -}}
-{{- if hasKey . "appArmorProfile" -}}
-  {{- $appArmorProfile = .appArmorProfile -}}
-{{- end -}}
-{{- $appArmorProfileLocalhost := "" -}}
-{{- if hasKey . "appArmorProfileLocalhost" -}}
-  {{- $appArmorProfileLocalhost = .appArmorProfileLocalhost -}}
 {{- end -}}
 {{- $caps := default (list) .caps -}}
 {{- $uid  := default 64535 .uid  -}}
@@ -121,13 +111,6 @@ securityContext:
 {{- if $seccompProfile }}
   seccompProfile:
     type: RuntimeDefault
-{{- end }}
-{{- if $appArmorProfile }}
-  appArmorProfile:
-    type: {{ $appArmorProfile }}
-{{- if and (eq $appArmorProfile "Localhost") $appArmorProfileLocalhost }}
-    localhostProfile: {{ $appArmorProfileLocalhost }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/helm_lib/templates/_module_security_context.tpl
+++ b/charts/helm_lib/templates/_module_security_context.tpl
@@ -76,9 +76,7 @@ securityContext:
 {{- /* .uid  – int, runAsUser/runAsGroup (default 64535) */ -}}
 {{- /* .runAsNonRoot   – bool, run as Deckhouse user when true, root when false (default true) */ -}}
 {{- /* .seccompProfile  – bool, disable seccompProfile when false (default true) */ -}}
-{{- /* .appArmorProfile – string, appArmorProfile.type, set to empty string to disable (default RuntimeDefault) */ -}}
-{{- /* .appArmorProfileLocalhost – string, appArmorProfile.localhostProfile, used only when appArmorProfile is "Localhost" (default empty) */ -}}
-{{- /* Usage: include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true "appArmorProfile" "Localhost" "appArmorProfileLocalhost" "k8s-apparmor-example-deny-write") */ -}}
+{{- /* Usage: include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" false "caps" (list "NET_ADMIN" "SYS_TIME") "uid" 1001 "seccompProfile" false "runAsNonRoot" true) */ -}}
 {{- define "helm_lib_module_container_security_context_pss_restricted_flexible" -}}
 {{- $ro := true -}}
 {{- if hasKey . "ro" -}}
@@ -87,14 +85,6 @@ securityContext:
 {{- $seccompProfile := true -}}
 {{- if hasKey . "seccompProfile" -}}
   {{- $seccompProfile = .seccompProfile -}}
-{{- end -}}
-{{- $appArmorProfile := "RuntimeDefault" -}}
-{{- if hasKey . "appArmorProfile" -}}
-  {{- $appArmorProfile = .appArmorProfile -}}
-{{- end -}}
-{{- $appArmorProfileLocalhost := "" -}}
-{{- if hasKey . "appArmorProfileLocalhost" -}}
-  {{- $appArmorProfileLocalhost = .appArmorProfileLocalhost -}}
 {{- end -}}
 {{- $caps := default (list) .caps -}}
 {{- $uid  := default 64535 .uid  -}}
@@ -121,13 +111,6 @@ securityContext:
 {{- if $seccompProfile }}
   seccompProfile:
     type: RuntimeDefault
-{{- end }}
-{{- if $appArmorProfile }}
-  appArmorProfile:
-    type: {{ $appArmorProfile }}
-{{- if and (eq $appArmorProfile "Localhost") $appArmorProfileLocalhost }}
-    localhostProfile: {{ $appArmorProfileLocalhost }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/tests/templates/helm_lib_module_container_security_context_pss_restricted_flexible_apparmor_custom.yaml
+++ b/tests/templates/helm_lib_module_container_security_context_pss_restricted_flexible_apparmor_custom.yaml
@@ -1,1 +1,0 @@
-{{ include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "appArmorProfile" "Localhost" "appArmorProfileLocalhost" "k8s-apparmor-example-deny-write") }}

--- a/tests/templates/helm_lib_module_container_security_context_pss_restricted_flexible_apparmor_disabled.yaml
+++ b/tests/templates/helm_lib_module_container_security_context_pss_restricted_flexible_apparmor_disabled.yaml
@@ -1,1 +1,0 @@
-{{ include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "appArmorProfile" "") }}

--- a/tests/tests/helm_lib_application_container_security_context_test.yaml
+++ b/tests/tests/helm_lib_application_container_security_context_test.yaml
@@ -18,13 +18,11 @@ tests:
             securityContext:
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false
-              appArmorProfile:
-                type: RuntimeDefault
               capabilities:
                 drop:
                   - ALL
               runAsUser: 64535
-              runAsGroup: 64535
+              runAsGroup: 64535  
               privileged: false
               runAsNonRoot: true
 
@@ -44,8 +42,6 @@ tests:
               runAsGroup: 64535
               runAsNonRoot: true
               seccompProfile:
-                type: RuntimeDefault
-              appArmorProfile:
                 type: RuntimeDefault
 
   - it: read_only_root_filesystem default options

--- a/tests/tests/helm_lib_module_container_security_context_pss_restricted_flexible_test_seccomp_disabled.yaml
+++ b/tests/tests/helm_lib_module_container_security_context_pss_restricted_flexible_test_seccomp_disabled.yaml
@@ -1,8 +1,8 @@
 suite: helm_lib_module_container_security_context_pss_restricted_flexible
 templates:
-  - helm_lib_module_container_security_context_pss_restricted_flexible.yaml
+  - helm_lib_module_container_security_context_pss_restricted_flexible_seccomp_disabled.yaml
 tests:
-  - it: default options
+  - it: seccompProfile disabled
     asserts:
       - equal:
           path: securityContext
@@ -13,8 +13,5 @@ tests:
               drop:
                 - ALL
             runAsUser: 64535
-            privileged: false
             runAsGroup: 64535
             runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault

--- a/tests/tests/helm_lib_module_init_container_test.yaml
+++ b/tests/tests/helm_lib_module_init_container_test.yaml
@@ -99,8 +99,6 @@ tests:
                   ephemeral-storage: 50Mi
               securityContext:
                 allowPrivilegeEscalation: false
-                appArmorProfile:
-                  type: RuntimeDefault
                 capabilities:
                   drop:
                     - ALL


### PR DESCRIPTION
This reverts PR #200 (commit 9f8a1ab), which added appArmor config values in `securityContext`.

Changes:
- Revert `9f8a1ab` — restores `_application_security_context.tpl`, `_module_security_context.tpl`, README, and the associated tests to their pre-#200 state.
- Bump chart version to `1.72.7` (the reverted PR had bumped it to `1.72.6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)