### PR TITLE
resolve vsphere-syncer image from module config instead of 000-common

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.10
+version: 1.72.11
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_csi_controller.tpl
+++ b/charts/helm_lib/templates/_csi_controller.tpl
@@ -58,6 +58,11 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "syncer_resources" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+
 {{- define "snapshotter_resources" }}
 cpu: 10m
 memory: 25Mi
@@ -82,6 +87,7 @@ memory: 50Mi
   {{- $snapshotterEnabled := dig "snapshotterEnabled" true $config }}
   {{- $snapshotterSnapshotNamePrefix := dig "snapshotterSnapshotNamePrefix" false $config }}
   {{- $resizerEnabled := dig "resizerEnabled" true $config }}
+  {{- $syncerEnabled := dig "syncerEnabled" false $config }}
   {{- $topologyEnabled := dig "topologyEnabled" true $config }}
   {{- $capacityEnabled := dig "capacityEnabled" true $config }}
   {{- $runAsRootUser := dig "runAsRootUser" false $config }}
@@ -100,6 +106,7 @@ memory: 50Mi
   {{- $csiControllerHaMode := $config.csiControllerHaMode | default false }}
   {{- $additionalCsiControllerPodAnnotations := $config.additionalCsiControllerPodAnnotations | default false }}
   {{- $additionalControllerEnvs := $config.additionalControllerEnvs }}
+  {{- $additionalSyncerEnvs := $config.additionalSyncerEnvs }}
   {{- $additionalControllerArgs := $config.additionalControllerArgs }}
   {{- $additionalControllerVolumes := $config.additionalControllerVolumes }}
   {{- $additionalControllerVolumeMounts := $config.additionalControllerVolumeMounts }}
@@ -125,6 +132,8 @@ memory: 50Mi
   {{- $attacherImage := include "helm_lib_csi_image_with_common_fallback" (list $context "csiExternalAttacher" $kubernetesSemVer) }}
 
   {{- $resizerImage := include "helm_lib_csi_image_with_common_fallback" (list $context "csiExternalResizer" $kubernetesSemVer) }}
+
+  {{- $syncerImage := dig "syncerImage" "" $config }}
 
   {{- $snapshotterImage := include "helm_lib_csi_image_with_common_fallback" (list $context "csiExternalSnapshotter" $kubernetesSemVer) }}
 
@@ -164,6 +173,14 @@ spec:
     - containerName: "resizer"
       minAllowed:
         {{- include "resizer_resources" $context | nindent 8 }}
+      maxAllowed:
+        cpu: 20m
+        memory: 50Mi
+    {{- end }}
+    {{- if and $syncerEnabled $syncerImage }}
+    - containerName: "syncer"
+      minAllowed:
+        {{- include "syncer_resources" $context | nindent 8 }}
       maxAllowed:
         cpu: 20m
         memory: 50Mi
@@ -385,6 +402,33 @@ spec:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
   {{- if not ( $context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
             {{- include "resizer_resources" $context | nindent 12 }}
+  {{- end }}
+            {{- end }}
+            {{- if and $syncerEnabled $syncerImage }}
+      - name: syncer
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" true "seccompProfile" true) | nindent 8 }}
+        image: {{ $syncerImage | quote }}
+        args:
+        - "--leader-election"
+        - "--leader-election-lease-duration=30s"
+        - "--leader-election-renew-deadline=20s"
+        - "--leader-election-retry-period=10s"
+    {{- if $additionalControllerArgs }}
+        {{- $additionalControllerArgs | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if $additionalSyncerEnvs }}
+        env:
+        {{- $additionalSyncerEnvs | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if $additionalControllerVolumeMounts }}
+        volumeMounts:
+        {{- $additionalControllerVolumeMounts | toYaml | nindent 8 }}
+    {{- end }}
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+  {{- if not ( $context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            {{- include "syncer_resources" $context | nindent 12 }}
   {{- end }}
             {{- end }}
     {{- if $snapshotterEnabled }}

--- a/charts/helm_lib/templates/_csi_controller.tpl
+++ b/charts/helm_lib/templates/_csi_controller.tpl
@@ -58,11 +58,6 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
-{{- define "syncer_resources" }}
-cpu: 10m
-memory: 25Mi
-{{- end }}
-
 {{- define "snapshotter_resources" }}
 cpu: 10m
 memory: 25Mi
@@ -87,7 +82,6 @@ memory: 50Mi
   {{- $snapshotterEnabled := dig "snapshotterEnabled" true $config }}
   {{- $snapshotterSnapshotNamePrefix := dig "snapshotterSnapshotNamePrefix" false $config }}
   {{- $resizerEnabled := dig "resizerEnabled" true $config }}
-  {{- $syncerEnabled := dig "syncerEnabled" false $config }}
   {{- $topologyEnabled := dig "topologyEnabled" true $config }}
   {{- $capacityEnabled := dig "capacityEnabled" true $config }}
   {{- $runAsRootUser := dig "runAsRootUser" false $config }}
@@ -106,7 +100,6 @@ memory: 50Mi
   {{- $csiControllerHaMode := $config.csiControllerHaMode | default false }}
   {{- $additionalCsiControllerPodAnnotations := $config.additionalCsiControllerPodAnnotations | default false }}
   {{- $additionalControllerEnvs := $config.additionalControllerEnvs }}
-  {{- $additionalSyncerEnvs := $config.additionalSyncerEnvs }}
   {{- $additionalControllerArgs := $config.additionalControllerArgs }}
   {{- $additionalControllerVolumes := $config.additionalControllerVolumes }}
   {{- $additionalControllerVolumeMounts := $config.additionalControllerVolumeMounts }}
@@ -132,9 +125,6 @@ memory: 50Mi
   {{- $attacherImage := include "helm_lib_csi_image_with_common_fallback" (list $context "csiExternalAttacher" $kubernetesSemVer) }}
 
   {{- $resizerImage := include "helm_lib_csi_image_with_common_fallback" (list $context "csiExternalResizer" $kubernetesSemVer) }}
-
-  {{- $syncerImageName := join "" (list "csiVsphereSyncer" $kubernetesSemVer.Major $kubernetesSemVer.Minor) }}
-  {{- $syncerImage := include "helm_lib_module_common_image_no_fail" (list $context $syncerImageName) }}
 
   {{- $snapshotterImage := include "helm_lib_csi_image_with_common_fallback" (list $context "csiExternalSnapshotter" $kubernetesSemVer) }}
 
@@ -174,14 +164,6 @@ spec:
     - containerName: "resizer"
       minAllowed:
         {{- include "resizer_resources" $context | nindent 8 }}
-      maxAllowed:
-        cpu: 20m
-        memory: 50Mi
-    {{- end }}
-    {{- if $syncerEnabled }}
-    - containerName: "syncer"
-      minAllowed:
-        {{- include "syncer_resources" $context | nindent 8 }}
       maxAllowed:
         cpu: 20m
         memory: 50Mi
@@ -403,33 +385,6 @@ spec:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
   {{- if not ( $context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
             {{- include "resizer_resources" $context | nindent 12 }}
-  {{- end }}
-            {{- end }}
-            {{- if $syncerEnabled }}
-      - name: syncer
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" true "seccompProfile" true) | nindent 8 }}
-        image: {{ $syncerImage | quote }}
-        args:
-        - "--leader-election"
-        - "--leader-election-lease-duration=30s"
-        - "--leader-election-renew-deadline=20s"
-        - "--leader-election-retry-period=10s"
-    {{- if $additionalControllerArgs }}
-        {{- $additionalControllerArgs | toYaml | nindent 8 }}
-    {{- end }}
-    {{- if $additionalSyncerEnvs }}
-        env:
-        {{- $additionalSyncerEnvs | toYaml | nindent 8 }}
-    {{- end }}
-    {{- if $additionalControllerVolumeMounts }}
-        volumeMounts:
-        {{- $additionalControllerVolumeMounts | toYaml | nindent 8 }}
-    {{- end }}
-        resources:
-          requests:
-            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-  {{- if not ( $context.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
-            {{- include "syncer_resources" $context | nindent 12 }}
   {{- end }}
             {{- end }}
     {{- if $snapshotterEnabled }}

--- a/tests/tests/helm_lib_csi_controller_test.yaml
+++ b/tests/tests/helm_lib_csi_controller_test.yaml
@@ -17,7 +17,6 @@ tests:
               csiExternalProvisioner125: csiControllerProvisioner125
               csiExternalResizer125: csiControllerResizer125
               csiExternalSnapshotter125: csiControllerSnapshotter125
-              csiVsphereSyncer125: csiControllerSyncer125
               csiLivenessprobe125: csiLivenessProbe125
         discovery:
           kubernetesVersion: "1.25"
@@ -25,6 +24,7 @@ tests:
       _testvalues:
         controllerImage: controllerImage
         syncerEnabled: "true"
+        syncerImage: "deckhouse.io/deckhouse/ce@csiControllerSyncer125"
 
     documentSelector:
       path: kind


### PR DESCRIPTION
Change how the vsphere-syncer sidecar image is resolved in `helm_lib_csi_controller_manifests`.
Previously the template resolved the image itself via `helm_lib_module_common_image_no_fail` 
(pulling `csiVsphereSyncer<Major><Minor>` from `000-common` digests).
Now the caller module passes the image explicitly via `syncerImage` in the config dict:

```yaml
{{- $_ := set $csiControllerConfig "syncerImage" $syncerImage }}
The syncer container (and its VPA policy) only renders when both syncerEnabled: true
and syncerImage is non-empty. This decouples lib-helm from the image location
and allows vSphere modules to move the image out of 000-common.

