### PR TITLE
feat: add werf deploy-dependency on controller to ValidatingWebhookConfiguration

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.7
+version: 1.72.8
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_controller.tpl
+++ b/charts/helm_lib/templates/_module_controller.tpl
@@ -369,11 +369,14 @@ spec:
   - matchConditions: optional match conditions
   - sideEffects: side effects (default: "None")
   - timeoutSeconds: timeout (default: 5)
+  - controllerName: name of the webhook-serving controller Deployment this configuration
+    depends on (default: "controller"). A werf.io/deploy-dependency annotation is added so
+    the ValidatingWebhookConfiguration is deployed only after that Deployment is ready.
 */ -}}
 {{- define "helm_lib_module_validating_webhook_configuration" }}
   {{- $context := index . 0 }}
   {{- $config := index . 1 }}
-  
+
   {{- $name := $config.name | required "$config.name is required" }}
   {{- $webhookName := $config.webhookName | required "$config.webhookName is required" }}
   {{- $valuesKey := $config.valuesKey | required "$config.valuesKey is required" }}
@@ -384,6 +387,7 @@ spec:
   {{- $matchConditions := $config.matchConditions }}
   {{- $sideEffects := $config.sideEffects | default "None" }}
   {{- $timeoutSeconds := $config.timeoutSeconds | default 5 }}
+  {{- $controllerName := $config.controllerName | default "controller" }}
 
   {{- /* Get module values and cert */ -}}
   {{- $moduleValues := index $context.Values $valuesKey }}
@@ -397,6 +401,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: "d8-{{ $context.Chart.Name }}-{{ $name }}"
+  annotations:
+    werf.io/deploy-dependency-controller: state=ready,kind=Deployment,name={{ $controllerName }},namespace=d8-{{ $context.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
 webhooks:
   - name: "d8-{{ $context.Chart.Name }}-{{ $webhookName }}.deckhouse.io"

--- a/tests/tests/helm_lib_module_validating_webhook_configuration_test.yaml
+++ b/tests/tests/helm_lib_module_validating_webhook_configuration_test.yaml
@@ -57,6 +57,37 @@ tests:
           path: webhooks[0].timeoutSeconds
           value: 5
 
+      - equal:
+          path: metadata.annotations["werf.io/deploy-dependency-controller"]
+          value: state=ready,kind=Deployment,name=controller,namespace=d8-test-module
+
+  - it: renders validating webhook configuration with custom controller deploy dependency
+    set:
+      testModule:
+        internal:
+          customWebhookCert:
+            ca: ca
+            crt: crt
+            key: key
+      _testvalues:
+        name: sc-validation
+        webhookName: sc-validation
+        valuesKey: testModule
+        webhookCertPath: internal.customWebhookCert
+        path: /sc-validate
+        controllerName: custom-controller
+        rules:
+          - apiGroups: ["storage.k8s.io"]
+            apiVersions: ["v1"]
+            operations: ["*"]
+            resources: ["storageclasses"]
+            scope: Cluster
+
+    asserts:
+      - equal:
+          path: metadata.annotations["werf.io/deploy-dependency-controller"]
+          value: state=ready,kind=Deployment,name=custom-controller,namespace=d8-test-module
+
   - it: renders validating webhook configuration for moduleconfigs with matchConditions
     set:
       testModule:


### PR DESCRIPTION
## What

Add a `werf.io/deploy-dependency-controller` annotation to the `ValidatingWebhookConfiguration` generated by `helm_lib_module_validating_webhook_configuration`.

## Why

The generated `ValidatingWebhookConfiguration` points at the webhook-serving controller `Service` but had no ordering guarantee. During a rollout werf could apply the webhook configuration before the controller `Deployment` became `Ready`, so any resource matching the webhook rules (e.g. `StorageClass` create/update) would fail admission until the backend came up.

With the annotation, werf deploys the `ValidatingWebhookConfiguration` only after the controller `Deployment` reaches the `Ready` state.

## Changes

- `_module_controller.tpl`: add `werf.io/deploy-dependency-controller: state=ready,kind=Deployment,name=<controllerName>,namespace=d8-<chart>` to the webhook configuration metadata. New optional `controllerName` config parameter (default: `controller`, matching the default `fullname` of `helm_lib_module_controller_manifests`).
- `Chart.yaml`: bump chart version `1.72.7` -> `1.72.8`.
- Tests: assert the default annotation and a custom `controllerName` override.

## Testing

`helm unittest tests/` — 346 tests passed, 81 suites.
