### PR TITLE
feat: also gate ValidatingWebhookConfiguration on webhook Service presence

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.8
+version: 1.72.9
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/templates/_module_controller.tpl
+++ b/charts/helm_lib/templates/_module_controller.tpl
@@ -370,8 +370,9 @@ spec:
   - sideEffects: side effects (default: "None")
   - timeoutSeconds: timeout (default: 5)
   - controllerName: name of the webhook-serving controller Deployment this configuration
-    depends on (default: "controller"). A werf.io/deploy-dependency annotation is added so
-    the ValidatingWebhookConfiguration is deployed only after that Deployment is ready.
+    depends on (default: "controller"). werf.io/deploy-dependency annotations are added so
+    the ValidatingWebhookConfiguration is deployed only after that Deployment is ready and
+    the webhook Service (serviceName) is present.
 */ -}}
 {{- define "helm_lib_module_validating_webhook_configuration" }}
   {{- $context := index . 0 }}
@@ -403,6 +404,7 @@ metadata:
   name: "d8-{{ $context.Chart.Name }}-{{ $name }}"
   annotations:
     werf.io/deploy-dependency-controller: state=ready,kind=Deployment,name={{ $controllerName }},namespace=d8-{{ $context.Chart.Name }}
+    werf.io/deploy-dependency-service: state=present,kind=Service,name={{ $serviceName }},namespace=d8-{{ $context.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
 webhooks:
   - name: "d8-{{ $context.Chart.Name }}-{{ $webhookName }}.deckhouse.io"

--- a/tests/tests/helm_lib_module_validating_webhook_configuration_test.yaml
+++ b/tests/tests/helm_lib_module_validating_webhook_configuration_test.yaml
@@ -61,6 +61,10 @@ tests:
           path: metadata.annotations["werf.io/deploy-dependency-controller"]
           value: state=ready,kind=Deployment,name=controller,namespace=d8-test-module
 
+      - equal:
+          path: metadata.annotations["werf.io/deploy-dependency-service"]
+          value: state=present,kind=Service,name=webhooks,namespace=d8-test-module
+
   - it: renders validating webhook configuration with custom controller deploy dependency
     set:
       testModule:
@@ -152,6 +156,10 @@ tests:
       - equal:
           path: webhooks[0].clientConfig.service.name
           value: custom-webhooks
+
+      - equal:
+          path: metadata.annotations["werf.io/deploy-dependency-service"]
+          value: state=present,kind=Service,name=custom-webhooks,namespace=d8-test-module
 
   - it: renders validating webhook configuration with custom timeout
     set:


### PR DESCRIPTION
## What

Add a second `werf.io/deploy-dependency-service` annotation to the `ValidatingWebhookConfiguration` generated by `helm_lib_module_validating_webhook_configuration`, gating it on the webhook `Service` being present.

## Why

Follow-up to #203. That change made the webhook configuration wait for the controller `Deployment` to become `Ready`, but werf could still apply the `ValidatingWebhookConfiguration` before the webhook `Service` existed. In that window admission requests have no routable backend behind `clientConfig.service`.

The configuration must be deployed only after **both** the controller `Deployment` is `Ready` **and** the webhook `Service` is present.

## Changes

- `_module_controller.tpl`: add `werf.io/deploy-dependency-service: state=present,kind=Service,name=<serviceName>,namespace=d8-<chart>` alongside the existing controller dependency. Uses the existing `serviceName` config parameter (default: `webhooks`).
- `Chart.yaml`: bump chart version `1.72.8` -> `1.72.9`.
- Tests: assert the Service dependency annotation for both the default and custom `serviceName`.

## Testing

`helm unittest tests/` — 346 tests passed, 81 suites.
