### PR TITLE
add gateway api version of helm_lib_module_https_cert_manager_cluster_issuer_name

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.9
+version: 1.72.10
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -71,6 +71,7 @@
 | [helm_lib_module_uri_scheme](#helm_lib_module_uri_scheme) |
 | [helm_lib_module_https_mode](#helm_lib_module_https_mode) |
 | [helm_lib_module_https_cert_manager_cluster_issuer_name](#helm_lib_module_https_cert_manager_cluster_issuer_name) |
+| [helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api](#helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api) |
 | [helm_lib_module_https_ingress_tls_enabled](#helm_lib_module_https_ingress_tls_enabled) |
 | [helm_lib_module_https_route_tls_enabled](#helm_lib_module_https_route_tls_enabled) |
 | [helm_lib_module_https_copy_custom_certificate](#helm_lib_module_https_copy_custom_certificate) |
@@ -893,6 +894,19 @@ list:
 #### Usage
 
 `{{ include "helm_lib_module_https_cert_manager_cluster_issuer_name" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
+
+
+### helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api
+
+ returns cluster issuer name compatible with gateway api scheme 
+
+#### Usage
+
+`{{ include "helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api" . }} `
 
 #### Arguments
 

--- a/charts/helm_lib/templates/_module_https.tpl
+++ b/charts/helm_lib/templates/_module_https.tpl
@@ -87,6 +87,21 @@ certManager:
   {{- $https_values.certManager.clusterIssuerName -}}
 {{- end -}}
 
+{{- /* Usage: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api" . }} */ -}}
+{{- /* returns cluster issuer name compatible with gateway api scheme */ -}}
+{{- define "helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api" -}}
+  {{- $context := . -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $issuerName := include "helm_lib_module_https_cert_manager_cluster_issuer_name" $context -}}
+  {{- $moduleGateway := dict -}}
+  {{- include "helm_lib_module_gateway" (list . $moduleGateway) -}}
+  {{- if $moduleGateway -}}
+    {{- if or (eq $issuerName "letsencrypt") (eq $issuerName "letsencrypt-staging") }}
+      {{- $issuerName = printf "%s-gateway-%s" $issuerName $moduleGateway.name }}
+    {{- end }}
+  {{- end -}}
+  {{- $issuerName -}}
+{{- end -}}
+
 {{- /* Usage: {{ if (include "helm_lib_module_https_cert_manager_cluster_issuer_is_dns01_challenge_solver" .) }} */ -}}
 {{- define "helm_lib_module_https_cert_manager_cluster_issuer_is_dns01_challenge_solver" -}}
   {{- $context := . -}} {{- /* Template context with .Values, .Chart, etc */ -}}

--- a/tests/templates/helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api.yaml
+++ b/tests/templates/helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api.yaml
@@ -1,0 +1,1 @@
+issuer_name: {{ include "helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api" . }}

--- a/tests/tests/helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api_test.yaml
+++ b/tests/tests/helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api_test.yaml
@@ -1,0 +1,56 @@
+suite: helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api definition
+templates:
+  - helm_lib_module_https_cert_manager_cluster_issuer_name_for_gateway_api.yaml
+set:
+  global:
+    modules:
+      gatewayAPIGateway:
+        name: global
+        namespace: d8-alb
+      https:
+        mode: "CertManager"
+        certManager:
+          clusterIssuerName: "global-issuer"
+    enabledModules: ["cert-manager"]
+tests:
+  - it: should return global cert manager cluster issuer name
+    asserts:
+      - equal:
+          path: "issuer_name"
+          value: "global-issuer"
+
+  - it: should return module cert manager cluster issuer name
+    set:
+      testModule:
+        https:
+          mode: "CertManager"
+          certManager:
+            clusterIssuerName: "module-issuer"
+    asserts:
+      - equal:
+          path: "issuer_name"
+          value: "module-issuer"
+
+  - it: should return gateway-related cert manager cluster issuer name
+    set:
+      testModule:
+        https:
+          mode: "CertManager"
+          certManager:
+            clusterIssuerName: "letsencrypt"
+    asserts:
+      - equal:
+          path: "issuer_name"
+          value: "letsencrypt-gateway-global"
+
+  - it: should return gateway-related cert manager cluster issuer name #2
+    set:
+      testModule:
+        https:
+          mode: "CertManager"
+          certManager:
+            clusterIssuerName: "letsencrypt-staging"
+    asserts:
+      - equal:
+          path: "issuer_name"
+          value: "letsencrypt-staging-gateway-global"


### PR DESCRIPTION
This PR adds yet another snippet for getting a cluster issuer name in case Gateway API with default DKP gatateway scheme is used.