### PR TITLE
feat: add helm_lib_api_version_exists and grant VRR RBAC to csi provisioner

### DIFF
--- a/charts/helm_lib/Chart.yaml
+++ b/charts/helm_lib/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: library
 name: deckhouse_lib_helm
-version: 1.72.12
+version: 1.72.13
 description: "Helm utils template definitions for Deckhouse modules."

--- a/charts/helm_lib/README.md
+++ b/charts/helm_lib/README.md
@@ -8,6 +8,7 @@
 | [helm_lib_admission_webhook_client_ca_certificate](#helm_lib_admission_webhook_client_ca_certificate) |
 | **Api Version And Kind** |
 | [helm_lib_kind_exists](#helm_lib_kind_exists) |
+| [helm_lib_api_version_exists](#helm_lib_api_version_exists) |
 | [helm_lib_get_api_version_by_kind](#helm_lib_get_api_version_by_kind) |
 | **Application Image** |
 | [helm_lib_application_image](#helm_lib_application_image) |
@@ -195,6 +196,21 @@ list:
 list:
 -  Template context with .Values, .Chart, etc 
 -  Kind name portion 
+
+
+### helm_lib_api_version_exists
+
+ returns "true" if the GVK is available: installed from modules' crds (global.discovery.apiVersions) or present in cluster discovery (Capabilities) 
+
+#### Usage
+
+`{{ if (include "helm_lib_api_version_exists" (list . "<group>/<version>/<Kind>")) }} `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  Group/version/kind string, e.g. "snapshot.storage.k8s.io/v1/VolumeSnapshotClass" 
 
 
 ### helm_lib_get_api_version_by_kind

--- a/charts/helm_lib/templates/_api_version_and_kind.tpl
+++ b/charts/helm_lib/templates/_api_version_and_kind.tpl
@@ -14,6 +14,16 @@
   {{- end }}
 {{- end -}}
 
+{{- /* Usage: {{ if (include "helm_lib_api_version_exists" (list . "<group>/<version>/<Kind>")) }} */ -}}
+{{- /* returns "true" if the GVK is available: installed from modules' crds (global.discovery.apiVersions) or present in cluster discovery (Capabilities) */ -}}
+{{- define "helm_lib_api_version_exists" -}}
+  {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $crdAPIVer := index . 1 -}} {{- /* Group/version/kind string, e.g. "snapshot.storage.k8s.io/v1/VolumeSnapshotClass" */ -}}
+  {{- if or ($context.Values.global.discovery.apiVersions | has $crdAPIVer) ($context.Capabilities.APIVersions.Has $crdAPIVer) -}}
+true
+  {{- end -}}
+{{- end -}}
+
 {{- /* Usage: {{ include "helm_lib_get_api_version_by_kind" (list . "<kind-name>") }} */ -}}
 {{- /* returns current apiVersion string, based on available helm capabilities, for the provided kind (not all kinds are supported) */ -}}
 {{- define "helm_lib_get_api_version_by_kind" }}

--- a/charts/helm_lib/templates/_csi_controller.tpl
+++ b/charts/helm_lib/templates/_csi_controller.tpl
@@ -730,6 +730,22 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch"]
+{{- if (include "helm_lib_api_version_exists" (list . "storage-foundation.deckhouse.io/v1alpha1/VolumeRestoreRequest")) }}
+# When storage-foundation is enabled, the stock external-provisioner is replaced with its fork
+# (see helm_lib_csi_image_with_common_fallback), which additionally runs the VolumeRestoreRequest
+# executor: a cluster-wide informer on volumerestorerequests that provisions the target volume and
+# creates the PV/PVC pair for it. The sidecar is deployed by the driver module, so its
+# provisioner SA needs these permissions in every module that uses this define.
+# volumerestorerequests/status is intentionally NOT granted: the status is owned by the
+# storage-foundation controller, which derives it from the target PVC; the sidecar only executes.
+- apiGroups: ["storage-foundation.deckhouse.io"]
+  resources: ["volumerestorerequests"]
+  verbs: ["get", "list", "watch"]
+# Complements the stock persistentvolumeclaims rule above (get/list/watch/update).
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["create", "patch"]
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/templates/helm_lib_api_version_exists.yaml
+++ b/tests/templates/helm_lib_api_version_exists.yaml
@@ -1,0 +1,1 @@
+result: {{ include "helm_lib_api_version_exists" (list . "snapshot.storage.k8s.io/v1/VolumeSnapshotClass") | quote }}

--- a/tests/templates/helm_lib_csi_controller_rbac.yaml
+++ b/tests/templates/helm_lib_csi_controller_rbac.yaml
@@ -1,3 +1,7 @@
-{{- $context := dict "Chart" (dict "Name" "test-chart") }}
+{{- $apiVersions := list }}
+{{- if .Values._testvalues }}
+  {{- $apiVersions = .Values._testvalues.apiVersions | default list }}
+{{- end }}
+{{- $context := dict "Chart" (dict "Name" "test-chart") "Values" (dict "global" (dict "discovery" (dict "apiVersions" $apiVersions))) "Capabilities" .Capabilities }}
 {{- $result := include "helm_lib_csi_controller_rbac" $context }}
 result_rbac: {{ $result | toString | quote }}

--- a/tests/tests/helm_lib_api_version_exists_test.yaml
+++ b/tests/tests/helm_lib_api_version_exists_test.yaml
@@ -1,0 +1,59 @@
+suite: helm_lib_api_version_exists
+templates:
+  - helm_lib_api_version_exists.yaml
+tests:
+  - it: returns true when the GVK comes from the modules' crds (global.discovery.apiVersions)
+    set:
+      global.discovery.apiVersions:
+        - snapshot.storage.k8s.io/v1/VolumeSnapshotClass
+    capabilities:
+      apiVersions:
+        - apps/v1/Deployment
+    asserts:
+      - equal:
+          path: "result"
+          value: "true"
+
+  - it: returns true when the GVK is only present in the cluster discovery (Capabilities)
+    set:
+      global.discovery.apiVersions: []
+    capabilities:
+      apiVersions:
+        - snapshot.storage.k8s.io/v1/VolumeSnapshotClass
+    asserts:
+      - equal:
+          path: "result"
+          value: "true"
+
+  - it: returns an empty string when the GVK is available in neither source
+    set:
+      global.discovery.apiVersions:
+        - snapshot.storage.k8s.io/v1beta1/VolumeSnapshotClass
+    capabilities:
+      apiVersions:
+        - apps/v1/Deployment
+    asserts:
+      - equal:
+          path: "result"
+          value: ""
+
+  - it: returns true without failing on empty capabilities
+    set:
+      global.discovery.apiVersions:
+        - snapshot.storage.k8s.io/v1/VolumeSnapshotClass
+    capabilities:
+      apiVersions:
+    asserts:
+      - equal:
+          path: "result"
+          value: "true"
+
+  - it: returns an empty string without failing on empty capabilities
+    set:
+      global.discovery.apiVersions: []
+    capabilities:
+      apiVersions:
+    asserts:
+      - equal:
+          path: "result"
+          value: ""

--- a/tests/tests/helm_lib_csi_controller_rbac_test.yaml
+++ b/tests/tests/helm_lib_csi_controller_rbac_test.yaml
@@ -12,3 +12,43 @@ tests:
       - matchRegex:
           path: result_rbac
           pattern: "module: test-chart"
+
+  - it: should not grant VolumeRestoreRequest permissions when the CRD is absent
+    capabilities:
+      apiVersions:
+        - apps/v1/Deployment
+    asserts:
+      - notMatchRegex:
+          path: result_rbac
+          pattern: "volumerestorerequests"
+
+  - it: should grant VolumeRestoreRequest permissions when the CRD comes from the modules' crds
+    set:
+      _testvalues:
+        apiVersions:
+          - storage-foundation.deckhouse.io/v1alpha1/VolumeRestoreRequest
+    capabilities:
+      apiVersions:
+        - apps/v1/Deployment
+    asserts:
+      - matchRegex:
+          path: result_rbac
+          pattern: 'resources: \["volumerestorerequests"\]'
+      - matchRegex:
+          path: result_rbac
+          pattern: 'verbs: \["get", "list", "watch"\]'
+      - matchRegex:
+          path: result_rbac
+          pattern: 'verbs: \["create", "patch"\]'
+      - notMatchRegex:
+          path: result_rbac
+          pattern: 'resources: \["volumerestorerequests/status"\]'
+
+  - it: should grant VolumeRestoreRequest permissions when the CRD is present in the cluster discovery
+    capabilities:
+      apiVersions:
+        - storage-foundation.deckhouse.io/v1alpha1/VolumeRestoreRequest
+    asserts:
+      - matchRegex:
+          path: result_rbac
+          pattern: 'resources: \["volumerestorerequests"\]'


### PR DESCRIPTION
## Overview

Preparation for the migration of CSI modules from `snapshot-controller` to `storage-foundation`.

Two changes, `charts/helm_lib` version bumped to `1.72.13`:

1. **New define `helm_lib_api_version_exists`** (`_api_version_and_kind.tpl`) — returns `"true"` when a `<group>/<version>/<Kind>` is available, checking two sources:
   - `.Values.global.discovery.apiVersions` — GVKs collected by deckhouse from the `crds/` directories of enabled modules and put into global values (a change there re-renders every module, so gates built on this helper open without manual action once the CRD provider is enabled);
   - `.Capabilities.APIVersions` — real cluster discovery, which also covers CRDs installed outside a deckhouse module (by hand, by a third-party operator, by vanilla external-snapshotter).

   The existing `helm_lib_kind_exists` is left untouched and is not reused: it `fail`s on empty capabilities, ignores `global.discovery.apiVersions` and matches the kind by suffix without the API group.

2. **VolumeRestoreRequest RBAC in `helm_lib_csi_controller_rbac`** — gated on the presence of `storage-foundation.deckhouse.io/v1alpha1/VolumeRestoreRequest`, the provisioner ClusterRole additionally gets:

   ```yaml
   - apiGroups: ["storage-foundation.deckhouse.io"]
     resources: ["volumerestorerequests"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["create", "patch"]
   ```

## Why the VRR rules belong here

When `storage-foundation` is enabled, `helm_lib_csi_image_with_common_fallback` replaces all CSI sidecars with the storage-foundation forks. The forked external-provisioner additionally runs the VolumeRestoreRequest executor: a cluster-wide informer on `volumerestorerequests` that provisions the target volume and creates the PV/PVC pair for it. The sidecar is deployed by the driver module, so its `csi` ServiceAccount needs those permissions in every module that uses this define — including modules without snapshot support, since the executor lives in the provisioner sidecar, not in the snapshotter one.

Today these permissions are handed out by the storage-foundation hook `040-vrr-provisioner-rbac` from a hardcoded namespace list containing a single `d8-sds-local-volume`, which leaves the other modules with a 403 loop on the informer (reproduced in `csi-nfs`). storage-foundation itself marks the hook a workaround. Static rules in lib-helm replace it: the hook is to be removed once this version is synced into deckhouse for the in-tree cloud providers.

Notes:

- `volumerestorerequests/status` is deliberately **not** granted. The status is set by the storage-foundation VRR controller from the state of the target PVC; the sidecar only executes, so it cannot fabricate a Ready status.
- `volumecapturerequests` are **not** granted either — VCRs are reconciled by the storage-foundation controller alone; the module's csi-snapshotter sidecar only needs the stock `external-snapshotter` role from this same define.
- The PVC rule complements the stock one (`get/list/watch/update`) up to `get/list/watch/create/update/patch` — the set the storage-foundation hook grants.
- RBAC rules referring to a non-existent CRD are harmless, so the gate here is about consistency with the module templates that will use the same helper, not about correctness. The ordering is safe anyway: VRR CRDs arrive together with storage-foundation being enabled, and the same `global.discovery.apiVersions` change re-renders the module, so the rules appear no later than the provisioner image is swapped for the fork.

## Tests

- New suite `tests/tests/helm_lib_api_version_exists_test.yaml`: GVK only in `global.discovery.apiVersions`, only in `Capabilities`, in neither, and empty capabilities (returns a value without failing).
- `helm_lib_csi_controller_rbac` suite extended with the CRD-present / CRD-absent cases; its test template now passes `global.discovery` and `Capabilities` in the context.
- `make ci/tests/unit` — 358 tests, all green. `make doc/diff` — clean (`charts/helm_lib/README.md` regenerated).

## For consumers of this helper

Templates that gate on the snapshot stack should use the marker GVK `snapshot.storage.k8s.io/v1/VolumeSnapshotClass` instead of `.Values.global.enabledModules | has "snapshot-controller"`, so that the gate does not depend on which module provides the CRDs:

```gotemplate
{{- if (include "helm_lib_api_version_exists" (list . "snapshot.storage.k8s.io/v1/VolumeSnapshotClass")) }}
```
